### PR TITLE
Partial build fixes (NuGet and CSharp reference)

### DIFF
--- a/tests/WebSharper.CSharp.Sitelets.Tests/WebSharper.CSharp.Sitelets.Tests.csproj
+++ b/tests/WebSharper.CSharp.Sitelets.Tests/WebSharper.CSharp.Sitelets.Tests.csproj
@@ -80,6 +80,9 @@
       <HintPath>..\..\build\$(Configuration)\FSharp.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Reflection.Metadata">
+      <HintPath>..\..\packages\System.Reflection.Metadata.Roslyn\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
   </ItemGroup>
   <Import Project="../../msbuild/WebSharper.CSharp.Internal.targets" />

--- a/tests/WebSharper.CSharp.Tests/WebSharper.CSharp.Tests.csproj
+++ b/tests/WebSharper.CSharp.Tests/WebSharper.CSharp.Tests.csproj
@@ -102,6 +102,9 @@
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
+    <Reference Include="System.Reflection.Metadata">
+      <HintPath>..\..\packages\System.Reflection.Metadata.Roslyn\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    </Reference>
     <Reference Include="WebSharper.Sitelets.Tests, Version=4.0.0.0, Culture=neutral, PublicKeyToken=dcd983dec8f76a71, processorArchitecture=MSIL" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I wanted to try out some of the recent fixes so tried to do a build from source, this lead to errors:

```
E:\dev\websharper>rebuild.cmd
The system cannot find the file specified.
The system cannot find the file specified.
Microsoft (R) Build Engine version 14.0.25420.1
Copyright (C) Microsoft Corporation. All rights reserved.

  Bootstrap -> E:\dev\websharper\build\Bootstrap\Bootstrap.exe
  Attempting to gather dependencies information for package 'NuGet.Core.2.12.0' with respect to project 'packages', targeting 'Any,Version=v0.0'
  Attempting to resolve dependencies for package 'NuGet.Core.2.12.0' with DependencyBehavior 'Lowest'
  Resolving actions to install package 'NuGet.Core.2.12.0'
  Resolved actions to install package 'NuGet.Core.2.12.0'
  Adding package 'Microsoft.Web.Xdt.2.1.1' to folder 'packages'
  Added package 'Microsoft.Web.Xdt.2.1.1' to folder 'packages'
  Successfully installed 'Microsoft.Web.Xdt 2.1.1' to packages
  Adding package 'NuGet.Core.2.12.0' to folder 'packages'
  Added package 'NuGet.Core.2.12.0' to folder 'packages'
  Successfully installed 'NuGet.Core 2.12.0' to packages
  Attempting to gather dependencies information for package 'IntelliFactory.Core.0.2.105.8-alpha' with respect to project 'packages', targeting 'Any,Version=v0
  .0'
  Attempting to resolve dependencies for package 'IntelliFactory.Core.0.2.105.8-alpha' with DependencyBehavior 'Lowest'
  Resolving actions to install package 'IntelliFactory.Core.0.2.105.8-alpha'
  Resolved actions to install package 'IntelliFactory.Core.0.2.105.8-alpha'
  Adding package 'IntelliFactory.Core.0.2.105.8-alpha' to folder 'packages'
  Added package 'IntelliFactory.Core.0.2.105.8-alpha' to folder 'packages'
  Successfully installed 'IntelliFactory.Core 0.2.105.8-alpha' to packages
  Attempting to gather dependencies information for package 'IntelliFactory.Build.0.2.107.8-alpha' with respect to project 'packages', targeting 'Any,Version=v
  0.0'
  Attempting to resolve dependencies for package 'IntelliFactory.Build.0.2.107.8-alpha' with DependencyBehavior 'Lowest'
  Resolving actions to install package 'IntelliFactory.Build.0.2.107.8-alpha'
  Resolved actions to install package 'IntelliFactory.Build.0.2.107.8-alpha'
  Adding package 'IntelliFactory.Core.0.2.105.8-alpha' to folder 'packages'
  Added package 'IntelliFactory.Core.0.2.105.8-alpha' to folder 'packages'
  Successfully installed 'IntelliFactory.Core 0.2.105.8-alpha' to packages
  Adding package 'Microsoft.Web.Xdt.2.1.1' to folder 'packages'
  Added package 'Microsoft.Web.Xdt.2.1.1' to folder 'packages'
  Successfully installed 'Microsoft.Web.Xdt 2.1.1' to packages
  Adding package 'NuGet.Core.2.12.0' to folder 'packages'
  Added package 'NuGet.Core.2.12.0' to folder 'packages'
  Successfully installed 'NuGet.Core 2.12.0' to packages
  Adding package 'IntelliFactory.Build.0.2.107.8-alpha' to folder 'packages'
  Added package 'IntelliFactory.Build.0.2.107.8-alpha' to folder 'packages'
  Successfully installed 'IntelliFactory.Build 0.2.107.8-alpha' to packages
  Attempting to gather dependencies information for package 'FSharp.Core.3.0.2' with respect to project 'packages', targeting 'Any,Version=v0.0'
  Attempting to resolve dependencies for package 'FSharp.Core.3.0.2' with DependencyBehavior 'Lowest'
  Resolving actions to install package 'FSharp.Core.3.0.2'
  Resolved actions to install package 'FSharp.Core.3.0.2'
  Adding package 'FSharp.Core.3.0.2' to folder 'packages'
  Added package 'FSharp.Core.3.0.2' to folder 'packages'
  Successfully installed 'FSharp.Core 3.0.2' to packages
  Attempting to gather dependencies information for package 'FSharp.Core.4.0.0.1' with respect to project 'packages', targeting 'Any,Version=v0.0'
  Attempting to resolve dependencies for package 'FSharp.Core.4.0.0.1' with DependencyBehavior 'Lowest'
  Resolving actions to install package 'FSharp.Core.4.0.0.1'
  Resolved actions to install package 'FSharp.Core.4.0.0.1'
  Adding package 'FSharp.Core.4.0.0.1' to folder 'packages'
  Added package 'FSharp.Core.4.0.0.1' to folder 'packages'
  Successfully installed 'FSharp.Core 4.0.0.1' to packages
  Attempting to gather dependencies information for package 'sharpcompress.0.15.1' with respect to project 'packages', targeting 'Any,Version=v0.0'
  Attempting to resolve dependencies for package 'sharpcompress.0.15.1' with DependencyBehavior 'Lowest'
  Resolving actions to install package 'sharpcompress.0.15.1'
  Resolved actions to install package 'sharpcompress.0.15.1'
EXEC : warning : Install failed. Rolling back... [E:\dev\websharper\src\build\WebSharper.Build\WebSharper.Build.fsproj]
  An error occurred while downloading package 'SharpCompress 0.15.1' from source 'https://www.nuget.org/api/v2/'.

  Unhandled Exception: System.Exception: ERROR in tools/NuGet/NuGet.exe install sharpcompress -version 0.15.1 -o packages -excludeVersion -nocache
     at WebSharper.Bootstrap.Main.Exec@70-12.Invoke(String message) in E:\dev\websharper\src\build\Bootstrap\Main.fs:line 70
     at WebSharper.Bootstrap.Main.Exec(IEnumerable`1 env, String command, String arguments) in E:\dev\websharper\src\build\Bootstrap\Main.fs:line 70
     at WebSharper.Bootstrap.Main.RestorePackages() in E:\dev\websharper\src\build\Bootstrap\Main.fs:line 83
     at WebSharper.Bootstrap.Main.Start(String[] args) in E:\dev\websharper\src\build\Bootstrap\Main.fs:line 97
E:\dev\websharper\src\build\WebSharper.Build\WebSharper.Build.fsproj(17,5): error MSB3073: The command " "E:\dev\websharper\msbuild\\../build/Bootstrap/Bootstr
ap.exe"" exited with code -532462766.##
```

when I investigated it appears the version of NuGet you're scripting has unexplained but repeatable errors with SharpCompress:

```
E:\dev\websharper>tools\NuGet\NuGet.exe install sharpcompress -version 0.15.1 -o packages -excludeVersion -nocache
Attempting to gather dependencies information for package 'sharpcompress.0.15.1' with respect to project 'packages', targeting 'Any,Version=v0.0'
Attempting to resolve dependencies for package 'sharpcompress.0.15.1' with DependencyBehavior 'Lowest'
Resolving actions to install package 'sharpcompress.0.15.1'
Resolved actions to install package 'sharpcompress.0.15.1'
WARNING: Install failed. Rolling back...
An error occurred while downloading package 'SharpCompress 0.15.1' from source 'https://www.nuget.org/api/v2/'.
```

I upgraded to the latest recommend from here https://dist.nuget.org/index.html (3.5.0) then was able to progress further. It gave me the WsFsc.exe build I needed at least.

I'm not sure it was related but I got a few errors in tests. One was related to Roslyn version of System.Reflection.Metadata.dll which I fixed up in a few projects. There are still some errors e.g. in a WARP test and `S.Action` seems to be missing but it's an improvement I believe.

Are those tests currently building for others?