### PR TITLE
Web workers

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -8,7 +8,7 @@ open System.IO
 open Fake
 open WebSharper.Fake
 
-let version = "4.3"
+let version = "4.4"
 let pre = None
 
 let baseVersion =

--- a/src/compiler/WebSharper.CSharp/Program.fs
+++ b/src/compiler/WebSharper.CSharp/Program.fs
@@ -128,13 +128,13 @@ let Compile config =
     let js, currentMeta, sources, extraBundles =
         if isBundleOnly then
             let currentMeta, sources = TransformMetaSources comp.AssemblyName (comp.ToCurrentMetadata(config.WarnOnly)) config.SourceMap 
-            let extraBundles = Bundling.AddExtraBundles config [refMeta] currentMeta refs comp (Choice1Of2 comp.AssemblyName)
+            let extraBundles = Bundling.AddExtraBundles config metas currentMeta refs comp (Choice1Of2 comp.AssemblyName)
             None, currentMeta, sources, extraBundles
         else
             let assem = loader.LoadFile config.AssemblyFile
             let currentMeta = comp.ToCurrentMetadata(config.WarnOnly)
 
-            let extraBundles = Bundling.AddExtraBundles config [refMeta] currentMeta refs comp (Choice2Of2 assem)
+            let extraBundles = Bundling.AddExtraBundles config metas currentMeta refs comp (Choice2Of2 assem)
 
             let js, currentMeta, sources =
                 ModifyAssembly (Some comp) refMeta currentMeta config.SourceMap config.AnalyzeClosures assem

--- a/src/compiler/WebSharper.CSharp/Program.fs
+++ b/src/compiler/WebSharper.CSharp/Program.fs
@@ -136,7 +136,7 @@ let Compile config =
             Bundling.AddExtraBundles config [refMeta] currentMeta refs comp assem
 
             let js, currentMeta, sources =
-                ModifyAssembly (Some comp) refMeta currentMeta config.SourceMap config.AnalyzeClosures assem
+                ModifyAssembly (Some comp) refMeta currentMeta config.SourceMap config.AnalyzeClosures config.ScriptBaseUrl assem
 
             match config.ProjectType with
             | Some (Bundle | Website) ->
@@ -171,7 +171,7 @@ let Compile config =
     match config.ProjectType with
     | Some (Bundle | BundleOnly) ->
         let currentJS =
-            lazy CreateBundleJSOutput refMeta currentMeta
+            lazy CreateBundleJSOutput refMeta currentMeta config.ScriptBaseUrl
         Bundling.Bundle config metas currentMeta comp.JavaScriptExports currentJS sources refs
         TimedStage "Bundling"
     | Some Html ->
@@ -264,6 +264,8 @@ let rec compileMain (argv: string[]) =
     let wsconfig = Path.Combine(Path.GetDirectoryName (!wsArgs).ProjectFile, "wsconfig.json")
     if File.Exists wsconfig then
         wsArgs := (!wsArgs).AddJson(File.ReadAllText wsconfig)
+
+    wsArgs := SetScriptBaseUrl !wsArgs
 
     try
         Compile !wsArgs

--- a/src/compiler/WebSharper.CSharp/Program.fs
+++ b/src/compiler/WebSharper.CSharp/Program.fs
@@ -137,7 +137,7 @@ let Compile config =
             let extraBundles = Bundling.AddExtraBundles config [refMeta] currentMeta refs comp (Choice2Of2 assem)
 
             let js, currentMeta, sources =
-                ModifyAssembly (Some comp) refMeta currentMeta config.SourceMap config.AnalyzeClosures config.ScriptBaseUrl assem
+                ModifyAssembly (Some comp) refMeta currentMeta config.SourceMap config.AnalyzeClosures assem
 
             match config.ProjectType with
             | Some (Bundle | Website) ->
@@ -172,7 +172,7 @@ let Compile config =
     match config.ProjectType with
     | Some (Bundle | BundleOnly) ->
         let currentJS =
-            lazy CreateBundleJSOutput refMeta currentMeta config.ScriptBaseUrl
+            lazy CreateBundleJSOutput refMeta currentMeta
         Bundling.Bundle config metas currentMeta comp currentJS sources refs extraBundles
         TimedStage "Bundling"
     | Some Html ->

--- a/src/compiler/WebSharper.CSharp/Program.fs
+++ b/src/compiler/WebSharper.CSharp/Program.fs
@@ -141,6 +141,8 @@ let Compile config =
                 AddExtraAssemblyReferences wsRefs assem
             | _ -> ()
 
+            Bundling.AddExtraBundles config [refMeta] currentMeta sources refs comp assem
+
             PrintWebSharperErrors config.WarnOnly comp
 
             if config.PrintJS then

--- a/src/compiler/WebSharper.CSharp/Program.fs
+++ b/src/compiler/WebSharper.CSharp/Program.fs
@@ -131,17 +131,17 @@ let Compile config =
             None, currentMeta, sources
         else
             let assem = loader.LoadFile config.AssemblyFile
+            let currentMeta = comp.ToCurrentMetadata(config.WarnOnly)
+
+            Bundling.AddExtraBundles config [refMeta] currentMeta refs comp assem
 
             let js, currentMeta, sources =
-                ModifyAssembly (Some comp) refMeta
-                    (comp.ToCurrentMetadata(config.WarnOnly)) config.SourceMap config.AnalyzeClosures assem
+                ModifyAssembly (Some comp) refMeta currentMeta config.SourceMap config.AnalyzeClosures assem
 
             match config.ProjectType with
             | Some (Bundle | Website) ->
                 AddExtraAssemblyReferences wsRefs assem
             | _ -> ()
-
-            Bundling.AddExtraBundles config [refMeta] currentMeta sources refs comp assem
 
             PrintWebSharperErrors config.WarnOnly comp
 

--- a/src/compiler/WebSharper.Compiler/Bundle.fs
+++ b/src/compiler/WebSharper.Compiler/Bundle.fs
@@ -327,6 +327,7 @@ module Bundling =
             { config with
                 SourceMap = false // TODO make SourceMap work with this
                 DeadCodeElimination = true
+                ScriptBaseUrl = Some "../"
             }
         let pub = Mono.Cecil.ManifestResourceAttributes.Public
         let addWebResourceAttribute =

--- a/src/compiler/WebSharper.Compiler/Bundle.fs
+++ b/src/compiler/WebSharper.Compiler/Bundle.fs
@@ -221,7 +221,7 @@ module Bundling =
                             match e.Urls ctx with
                             | [||] -> ()
                             | urls ->
-                                writer.WriteLine("importScripts([{0}])",
+                                writer.WriteLine("importScripts([{0}]);",
                                     urls |> Seq.map (fun url ->
                                         let s = W.ExpressionToString WebSharper.Core.JavaScript.Preferences.Compact !~(JS.String url)
                                         s.Trim()

--- a/src/compiler/WebSharper.Compiler/Bundle.fs
+++ b/src/compiler/WebSharper.Compiler/Bundle.fs
@@ -349,7 +349,7 @@ module Bundling =
                 assem.Raw.CustomAttributes.Add(attr)
         let assemName = match assem with Choice1Of2 n -> n | Choice2Of2 a -> a.Name
         [
-            for KeyValue(bname, (bexpr, bnode)) in comp.CompilingExtraBundles do
+            for KeyValue(bname, (bexpr, bnode)) in comp.CompiledExtraBundles do
                 let bname = assemName + "." + bname
                 let currentMeta = { currentMeta with EntryPoint = Some (ExprStatement bexpr) }
                 let bundle = CreateBundle config refMetas currentMeta (getDeps [] [bnode]) Packager.EntryPointStyle.ForceImmediate (lazy None) [] refAssemblies

--- a/src/compiler/WebSharper.Compiler/CommandTools.fs
+++ b/src/compiler/WebSharper.Compiler/CommandTools.fs
@@ -60,6 +60,7 @@ type WsConfig =
         IsDebug : bool
         ProjectType : ProjectType option
         OutputDir  : string option
+        ScriptBaseUrl : string option
         AssemblyFile : string
         References  : string[] 
         Resources : (string * string option)[]
@@ -91,6 +92,7 @@ type WsConfig =
              IsDebug = false
              ProjectType = None
              OutputDir  = None
+             ScriptBaseUrl = None
              AssemblyFile = null
              References  = [||]
              Resources = [||]
@@ -159,6 +161,8 @@ type WsConfig =
                 res <- { res with ProjectType = ProjectType.Parse (getString k v) }
             | "outputdir" ->
                 res <- { res with OutputDir = Some (getPath k v) }
+            | "scriptbaseurl" ->
+                res <- { res with ScriptBaseUrl = Some (getString k v) }
             | "dce" ->
                 res <- { res with DeadCodeElimination = getBool k v }
             | "sourcemap" ->
@@ -468,6 +472,7 @@ let RecognizeWebSharperArg a wsArgs =
         | _ ->
             printfn "--closures:%s argument unrecognized, must be one of: true, false, movetotop" c
             Some wsArgs
+    | StartsWith "--scriptbaseurl" u -> Some { wsArgs with ScriptBaseUrl = Some u }
     | _ -> 
         None
 
@@ -480,4 +485,10 @@ let SetDefaultProjectFile wsArgs isFSharp =
         | [| p |] -> { wsArgs with ProjectFile = p }
         | [| |] -> argError "Cannot find project file, specify argument --project"
         | _ -> argError "Multiple project files in folder, specify argument --project"
+    | _ -> wsArgs
+
+let SetScriptBaseUrl wsArgs =
+    match wsArgs.ProjectType, wsArgs.ScriptBaseUrl with
+    | Some (Bundle | BundleOnly), None -> { wsArgs with ScriptBaseUrl = Some "/Content/" }
+    | Some Html, None -> { wsArgs with ScriptBaseUrl = Some "/Scripts/" }
     | _ -> wsArgs

--- a/src/compiler/WebSharper.Compiler/Compilation.fs
+++ b/src/compiler/WebSharper.Compiler/Compilation.fs
@@ -817,10 +817,6 @@ type Compilation(meta: Info, ?hasGraph) =
             |> Seq.find shouldAdd
         let node = ExtraBundleEntryPointNode(this.AssemblyName, computedName)
         compilingExtraBundles.Add(computedName, (entryPoint, node))
-        let location =
-            match entryPoint with
-            | Expression.ExprSourcePos(pos, _) -> Some pos
-            | _ -> None
         { AssemblyName = this.AssemblyName; BundleName = computedName }
 
     member this.Resolve () =

--- a/src/compiler/WebSharper.Compiler/Compilation.fs
+++ b/src/compiler/WebSharper.Compiler/Compilation.fs
@@ -49,7 +49,7 @@ type Compilation(meta: Info, ?hasGraph) =
     let compilingConstructors = Dictionary<TypeDefinition * Constructor, CompilingMember * Expression>()
     let compilingStaticConstructors = Dictionary<TypeDefinition, Address * Expression>()
     let compilingQuotedArgMethods = Dictionary<TypeDefinition * Method, int[]>()
-    let compilingExtraBundles = Dictionary<string, Expression>()
+    let compilingExtraBundles = Dictionary<string, Expression * Node>()
 
     let mutable generatedClass = None
     let mutable resolver = None : option<Resolve.Resolver>
@@ -793,7 +793,8 @@ type Compilation(meta: Info, ?hasGraph) =
         let add name =
             let doAdd = not <| compilingExtraBundles.ContainsKey(name)
             if doAdd then
-                compilingExtraBundles.Add(name, entryPoint)
+                let node = AssemblyNode("$$$" + name, true)
+                compilingExtraBundles.Add(name, (entryPoint, node))
             doAdd
         if add name then
             name

--- a/src/compiler/WebSharper.Compiler/Compilation.fs
+++ b/src/compiler/WebSharper.Compiler/Compilation.fs
@@ -796,9 +796,8 @@ type Compilation(meta: Info, ?hasGraph) =
                 let node = AssemblyNode("$$$" + name, true)
                 compilingExtraBundles.Add(name, (entryPoint, node))
             doAdd
-        if add name then
-            name
-        else
+        let name =
+            if add name then name else
             let rec tryAdd i =
                 let name = name + string i
                 if add name then
@@ -806,6 +805,7 @@ type Compilation(meta: Info, ?hasGraph) =
                 else
                     tryAdd (i + 1)
             tryAdd 1
+        this.AssemblyName + "." + name
 
     member this.Resolve () =
         

--- a/src/compiler/WebSharper.Compiler/FrontEnd.fs
+++ b/src/compiler/WebSharper.Compiler/FrontEnd.fs
@@ -113,10 +113,10 @@ let TransformMetaSources assemblyName (current: M.Info) sourceMap =
     else
         removeSourcePositionFromMetadata current, [||]
 
-let CreateBundleJSOutput refMeta current scriptBaseUrl =
+let CreateBundleJSOutput refMeta current =
 
     let pkg = 
-        Packager.packageAssembly refMeta current Packager.EntryPointStyle.OnLoadIfExists scriptBaseUrl
+        Packager.packageAssembly refMeta current Packager.EntryPointStyle.OnLoadIfExists
 
     if pkg = AST.Undefined then None else
 
@@ -129,7 +129,7 @@ let CreateBundleJSOutput refMeta current scriptBaseUrl =
 
         Some (js, minJs)
 
-let CreateResources (comp: Compilation option) (refMeta: M.Info) (current: M.Info) sourceMap closures scriptBaseUrl (a: Mono.Cecil.AssemblyDefinition) =
+let CreateResources (comp: Compilation option) (refMeta: M.Info) (current: M.Info) sourceMap closures (a: Mono.Cecil.AssemblyDefinition) =
     let assemblyName = a.Name.Name
     let currentPosFixed, sources =
         TransformMetaSources assemblyName current sourceMap
@@ -137,7 +137,7 @@ let CreateResources (comp: Compilation option) (refMeta: M.Info) (current: M.Inf
     TimedStage "Source position transformations"
 
     let pkg = 
-        Packager.packageAssembly refMeta current Packager.EntryPointStyle.OnLoadIfExists scriptBaseUrl
+        Packager.packageAssembly refMeta current Packager.EntryPointStyle.OnLoadIfExists
 
     TimedStage "Packaging assembly"
     
@@ -224,16 +224,16 @@ let CreateResources (comp: Compilation option) (refMeta: M.Info) (current: M.Inf
         addMeta()
         None, currentPosFixed, sources, res.ToArray()
 
-let ModifyCecilAssembly (comp: Compilation option) (refMeta: M.Info) (current: M.Info) sourceMap closures scriptBaseUrl (a: Mono.Cecil.AssemblyDefinition) =
-    let jsOpt, currentPosFixed, sources, res = CreateResources comp refMeta current sourceMap closures scriptBaseUrl a
+let ModifyCecilAssembly (comp: Compilation option) (refMeta: M.Info) (current: M.Info) sourceMap closures (a: Mono.Cecil.AssemblyDefinition) =
+    let jsOpt, currentPosFixed, sources, res = CreateResources comp refMeta current sourceMap closures a
     let pub = Mono.Cecil.ManifestResourceAttributes.Public
     for name, contents in res do
         Mono.Cecil.EmbeddedResource(name, pub, contents)
         |> a.MainModule.Resources.Add
     jsOpt, currentPosFixed, sources
 
-let ModifyAssembly (comp: Compilation option) (refMeta: M.Info) (current: M.Info) sourceMap closures scriptBaseUrl (assembly : Assembly) =
-    ModifyCecilAssembly comp refMeta current sourceMap closures scriptBaseUrl assembly.Raw
+let ModifyAssembly (comp: Compilation option) (refMeta: M.Info) (current: M.Info) sourceMap closures (assembly : Assembly) =
+    ModifyCecilAssembly comp refMeta current sourceMap closures assembly.Raw
 
 let AddExtraAssemblyReferences (wsrefs: Assembly seq) (assembly : Assembly) =
     let a = assembly.Raw
@@ -269,9 +269,12 @@ type ResourceContext =
 
         /// Decides how to render a resource.
         RenderResource : ResourceContent -> Resources.Rendering
+
+        /// Base URL path for WebSharper scripts.
+        ScriptBaseUrl : option<string>
     }
 
-let RenderDependencies(ctx: ResourceContext, writer: HtmlTextWriter, nameOfSelf, selfJS, deps: Resources.IResource list, lookupAssemblyCode) =
+let RenderDependencies(ctx: ResourceContext, writer: HtmlTextWriter, nameOfSelf, selfJS, deps: Resources.IResource list, lookupAssemblyCode, scriptBaseUrl) =
     let pU = WebSharper.PathConventions.PathUtility.VirtualPaths("/")
     let cache = Dictionary()
     let getRendering (content: ResourceContent) =
@@ -295,6 +298,7 @@ let RenderDependencies(ctx: ResourceContext, writer: HtmlTextWriter, nameOfSelf,
         {
             DebuggingEnabled = ctx.DebuggingEnabled
             DefaultToHttp = ctx.DefaultToHttp
+            ScriptBaseUrl = ctx.ScriptBaseUrl
             GetAssemblyRendering = fun name ->
                 if name = nameOfSelf then
                     selfJS
@@ -317,4 +321,4 @@ let RenderDependencies(ctx: ResourceContext, writer: HtmlTextWriter, nameOfSelf,
         }
     for d in deps do
         d.Render ctx (fun _ -> writer)
-    Utility.WriteStartCode true writer
+    Resources.HtmlTextWriter.WriteStartCode(writer, scriptBaseUrl)

--- a/src/compiler/WebSharper.Compiler/FrontEnd.fs
+++ b/src/compiler/WebSharper.Compiler/FrontEnd.fs
@@ -116,7 +116,7 @@ let TransformMetaSources assemblyName (current: M.Info) sourceMap =
 let CreateBundleJSOutput refMeta current =
 
     let pkg = 
-        Packager.packageAssembly refMeta current false
+        Packager.packageAssembly refMeta current Packager.EntryPointStyle.OnLoadIfExists
 
     if pkg = AST.Undefined then None else
 
@@ -137,7 +137,7 @@ let CreateResources (comp: Compilation option) (refMeta: M.Info) (current: M.Inf
     TimedStage "Source position transformations"
 
     let pkg = 
-        Packager.packageAssembly refMeta current false
+        Packager.packageAssembly refMeta current Packager.EntryPointStyle.OnLoadIfExists
 
     TimedStage "Packaging assembly"
     

--- a/src/compiler/WebSharper.Compiler/Packager.fs
+++ b/src/compiler/WebSharper.Compiler/Packager.fs
@@ -33,7 +33,7 @@ type EntryPointStyle =
     | ForceOnLoad
     | ForceImmediate
 
-let packageAssembly (refMeta: M.Info) (current: M.Info) entryPointStyle =
+let packageAssembly (refMeta: M.Info) (current: M.Info) entryPointStyle scriptsBaseUrl =
     let addresses = Dictionary()
     let declarations = ResizeArray()
     let statements = ResizeArray()
@@ -208,6 +208,12 @@ let packageAssembly (refMeta: M.Info) (current: M.Info) entryPointStyle =
         let (KeyValue(t, c)) = classes |> Seq.head
         classes.Remove t |> ignore
         packageClass c t.Value.FullName
+
+    scriptsBaseUrl |> Option.iter (fun url ->
+        ItemSet(Global ["IntelliFactory"; "Runtime"], !~(String "ScriptBasePath"), !~(String url))
+        |> ExprStatement
+        |> statements.Add
+    )
 
     match entryPointStyle, current.EntryPoint with
     | (OnLoadIfExists | ForceOnLoad), Some ep ->

--- a/src/compiler/WebSharper.Compiler/Packager.fs
+++ b/src/compiler/WebSharper.Compiler/Packager.fs
@@ -33,7 +33,7 @@ type EntryPointStyle =
     | ForceOnLoad
     | ForceImmediate
 
-let packageAssembly (refMeta: M.Info) (current: M.Info) entryPointStyle scriptsBaseUrl =
+let packageAssembly (refMeta: M.Info) (current: M.Info) entryPointStyle =
     let addresses = Dictionary()
     let declarations = ResizeArray()
     let statements = ResizeArray()
@@ -208,12 +208,6 @@ let packageAssembly (refMeta: M.Info) (current: M.Info) entryPointStyle scriptsB
         let (KeyValue(t, c)) = classes |> Seq.head
         classes.Remove t |> ignore
         packageClass c t.Value.FullName
-
-    scriptsBaseUrl |> Option.iter (fun url ->
-        ItemSet(Global ["IntelliFactory"; "Runtime"], !~(String "ScriptBasePath"), !~(String url))
-        |> ExprStatement
-        |> statements.Add
-    )
 
     match entryPointStyle, current.EntryPoint with
     | (OnLoadIfExists | ForceOnLoad), Some ep ->

--- a/src/compiler/WebSharper.Compiler/Recognize.fs
+++ b/src/compiler/WebSharper.Compiler/Recognize.fs
@@ -272,6 +272,8 @@ let wsRuntimeFunctions =
         "Curried2"
         "Curried3"
         "UnionByType"
+        "ScriptBasePath"
+        "ScriptPath"
     ]
 
 let rec transformExpression (env: Environment) (expr: S.Expression) =

--- a/src/compiler/WebSharper.Compiler/Reflector.fs
+++ b/src/compiler/WebSharper.Compiler/Reflector.fs
@@ -338,6 +338,7 @@ let trAsm (prototypes: IDictionary<string, string>) (assembly : Mono.Cecil.Assem
         MacroEntries = Map.empty
         Quotations = Map.empty
         ResourceHashes = Dictionary()
+        ExtraBundles = Set.empty
     }
 
 let TransformAssembly prototypes assembly =

--- a/src/compiler/WebSharper.Compiler/Translator.fs
+++ b/src/compiler/WebSharper.Compiler/Translator.fs
@@ -685,17 +685,17 @@ type DotNetToJavaScript private (comp: Compilation, ?inProgress) =
             comp.EntryPoint <- Some (toJS.TransformStatement(ep))
         | _ -> ()
 
-        for k in comp.CompilingExtraBundles.Keys |> Array.ofSeq do
-            let toJS = DotNetToJavaScript(comp)
-            let entryPoint, node = comp.CompilingExtraBundles.[k]
-            let compiledEntryPoint = toJS.CompileEntryPoint(entryPoint, node)
-            comp.CompilingExtraBundles.[k] <- (compiledEntryPoint, node)
-
         let compileMethods() =
             while comp.CompilingMethods.Count > 0 do
                 let toJS = DotNetToJavaScript(comp)
                 let (KeyValue((t, m), (i, e))) = Seq.head comp.CompilingMethods
                 toJS.CompileMethod(i, e, t, m)
+
+            for k in comp.CompilingExtraBundles.Keys |> Array.ofSeq do
+                let toJS = DotNetToJavaScript(comp)
+                let entryPoint, node = comp.CompilingExtraBundles.[k]
+                let compiledEntryPoint = toJS.CompileEntryPoint(entryPoint, node)
+                comp.AddCompiledExtraBundle(k, compiledEntryPoint, node)
 
         compileMethods()
         comp.CloseMacros()

--- a/src/compiler/WebSharper.Compiler/Translator.fs
+++ b/src/compiler/WebSharper.Compiler/Translator.fs
@@ -678,6 +678,10 @@ type DotNetToJavaScript private (comp: Compilation, ?inProgress) =
             comp.EntryPoint <- Some (toJS.TransformStatement(ep))
         | _ -> ()
 
+        for k in comp.CompilingExtraBundles.Keys |> Array.ofSeq do
+            let toJS = DotNetToJavaScript(comp)
+            comp.CompilingExtraBundles.[k] <- toJS.TransformExpression(comp.CompilingExtraBundles.[k])
+
         let compileMethods() =
             while comp.CompilingMethods.Count > 0 do
                 let toJS = DotNetToJavaScript(comp)

--- a/src/compiler/WebSharper.Compiler/Translator.fs
+++ b/src/compiler/WebSharper.Compiler/Translator.fs
@@ -659,7 +659,7 @@ type DotNetToJavaScript private (comp: Compilation, ?inProgress) =
     member this.CompileEntryPoint(expr, node) =
         try
             currentNode <- node
-            this.TransformExpression(expr)
+            this.TransformExpression(expr) |> breakExpr |> this.CheckResult
         with e ->
             this.Error(sprintf "Unexpected error during JavaScript compilation: %s at %s" e.Message e.StackTrace)
 
@@ -694,7 +694,6 @@ type DotNetToJavaScript private (comp: Compilation, ?inProgress) =
             while comp.CompilingExtraBundles.Count > 0 do
                 let toJS = DotNetToJavaScript(comp)
                 let (KeyValue(k, (entryPoint, node))) = Seq.head comp.CompilingExtraBundles
-                let entryPoint, node = comp.CompilingExtraBundles.[k]
                 let compiledEntryPoint = toJS.CompileEntryPoint(entryPoint, node)
                 comp.AddCompiledExtraBundle(k, compiledEntryPoint, node)
 

--- a/src/compiler/WebSharper.Compiler/Utility.fs
+++ b/src/compiler/WebSharper.Compiler/Utility.fs
@@ -68,13 +68,3 @@ module internal Utility =
             (content, contentType)
         with e ->
             ("", CT.Text.Plain)
-
-    /// Writes WebSharper startup code to a text writer.
-    let WriteStartCode (withScript: bool) (writer: TextWriter) =
-        writer.WriteLine()
-        if withScript then
-            writer.WriteLine("<script type='{0}'>", CT.Text.JavaScript.Text)
-        writer.WriteLine @"if (typeof IntelliFactory !=='undefined')"
-        writer.WriteLine @"  IntelliFactory.Runtime.Start();"
-        if withScript then
-            writer.WriteLine("</script>")

--- a/src/compiler/WebSharper.Core.JavaScript/Runtime.js
+++ b/src/compiler/WebSharper.Core.JavaScript/Runtime.js
@@ -257,10 +257,14 @@ IntelliFactory = {
 
         OnLoad:
             function (f) {
-                if (!("load" in this)) {
-                    this.load = [];
+                if (self instanceof Window) {
+                    if (!("load" in this)) {
+                        this.load = [];
+                    }
+                    this.load.push(f);
+                } else {
+                    f();
                 }
-                this.load.push(f);
             },
 
         Start:

--- a/src/compiler/WebSharper.Core.JavaScript/Runtime.js
+++ b/src/compiler/WebSharper.Core.JavaScript/Runtime.js
@@ -255,6 +255,12 @@ IntelliFactory = {
             }
         },
 
+        ScriptBasePath: "/Scripts/WebSharper/",
+
+        ScriptPath: function (a, f) {
+            return this.ScriptBasePath + a + "/" + f;
+        },
+
         OnLoad:
             function (f) {
                 if (!("load" in this)) {

--- a/src/compiler/WebSharper.Core.JavaScript/Runtime.js
+++ b/src/compiler/WebSharper.Core.JavaScript/Runtime.js
@@ -257,14 +257,10 @@ IntelliFactory = {
 
         OnLoad:
             function (f) {
-                if (self instanceof Window) {
-                    if (!("load" in this)) {
-                        this.load = [];
-                    }
-                    this.load.push(f);
-                } else {
-                    f();
+                if (!("load" in this)) {
+                    this.load = [];
                 }
+                this.load.push(f);
             },
 
         Start:

--- a/src/compiler/WebSharper.Core.JavaScript/Runtime.js
+++ b/src/compiler/WebSharper.Core.JavaScript/Runtime.js
@@ -255,10 +255,10 @@ IntelliFactory = {
             }
         },
 
-        ScriptBasePath: "/Scripts/WebSharper/",
+        ScriptBasePath: "./",
 
         ScriptPath: function (a, f) {
-            return this.ScriptBasePath + a + "/" + f;
+            return this.ScriptBasePath + (this.ScriptSkipAssemblyDir ? "" : a + "/") + f;
         },
 
         OnLoad:

--- a/src/compiler/WebSharper.Core/Macros.fs
+++ b/src/compiler/WebSharper.Core/Macros.fs
@@ -1422,5 +1422,10 @@ type WebWorker() =
                 Application(e, [Global []], NonPure, Some 1)
         // TODO: full path? .min?
         let filename = c.Compilation.AddBundle("worker", e) + ".js"
-        Ctor(worker, workerCtor, [!~(Literal.String filename)])
+        let path = 
+            Application(
+                Global ["IntelliFactory"; "Runtime"; "ScriptPath"],
+                [!~(Literal.String c.Compilation.AssemblyName); !~(Literal.String filename)],
+                NonPure, Some 2)
+        Ctor(worker, workerCtor, [path])
         |> MacroOk

--- a/src/compiler/WebSharper.Core/Macros.fs
+++ b/src/compiler/WebSharper.Core/Macros.fs
@@ -1420,8 +1420,8 @@ type WebWorker() =
                 Let(self, Global[], body)
             | e ->
                 Application(e, [Global []], NonPure, Some 1)
-        // TODO: full path? .min?
-        let filename = c.Compilation.AddBundle("worker", e) + ".js"
+        // TODO: .min?
+        let filename = c.Compilation.AddBundle("worker", e).FileName
         let path = 
             Application(
                 Global ["IntelliFactory"; "Runtime"; "ScriptPath"],

--- a/src/compiler/WebSharper.Core/Macros.fsi
+++ b/src/compiler/WebSharper.Core/Macros.fsi
@@ -160,4 +160,9 @@ type TupleExtensions =
     new : unit -> TupleExtensions
     inherit Macro
 
+[<Sealed>]
+type WebWorker =
+    new : unit -> WebWorker
+    inherit Macro
+
 val UncheckedEquals : AST.Expression -> AST.Expression -> AST.Expression

--- a/src/compiler/WebSharper.Core/Metadata.fs
+++ b/src/compiler/WebSharper.Core/Metadata.fs
@@ -478,7 +478,8 @@ type ICompilation =
     abstract AddMetadataEntry : MetadataEntry * MetadataEntry -> unit
     abstract AddError : option<SourcePos> * string -> unit 
     abstract AddWarning : option<SourcePos> * string -> unit 
-              
+    abstract AddBundle : name: string * entryPoint: Expression -> string
+
 module IO =
     module B = Binary
 

--- a/src/compiler/WebSharper.Core/Metadata.fs
+++ b/src/compiler/WebSharper.Core/Metadata.fs
@@ -248,7 +248,7 @@ type Node =
     | ResourceNode of TypeDefinition * option<ParameterObject>
     | AssemblyNode of string * bool
     | EntryPointNode 
-    | ExtraBundleEntryPointNode of string
+    | ExtraBundleEntryPointNode of string * string
 
 type GraphData =
     {

--- a/src/compiler/WebSharper.Core/PathConventions.fs
+++ b/src/compiler/WebSharper.Core/PathConventions.fs
@@ -85,6 +85,10 @@ module PathConventions =
         let content = root ++  "Content" ++ "WebSharper"
         let scripts = root ++ "Scripts" ++ "WebSharper"
 
+        member p.ContentBasePath = content
+
+        member p.ScriptBasePath = scripts
+
         member p.JavaScriptFileName(a) =
             a.ShortName + ".js"
 

--- a/src/compiler/WebSharper.Core/PathConventions.fsi
+++ b/src/compiler/WebSharper.Core/PathConventions.fsi
@@ -98,6 +98,12 @@ module PathConventions =
         /// Filename for the `.d.ts` TypeScript file corresponding to an assembly.
         member TypeScriptDefinitionsFileName : AssemblyId -> string
 
+        /// Base path for content URLs.
+        member ContentBasePath : string
+
+        /// Base path for script URLs.
+        member ScriptBasePath : string
+
         /// Constructs a utiltiy object based on the physical path to the
         /// web root folder, which can be obtained by `Server.MapPath("~")`.
         static member FileSystem : rootDirectory: string -> PathUtility

--- a/src/compiler/WebSharper.Core/Resources.fsi
+++ b/src/compiler/WebSharper.Core/Resources.fsi
@@ -44,6 +44,8 @@ type HtmlTextWriter =
     new : System.IO.TextWriter -> HtmlTextWriter
     new : System.IO.TextWriter * indent: string -> HtmlTextWriter
     static member IsSelfClosingTag : string -> bool
+    member WriteStartCode : scriptBaseUrl: option<string> * ?includeScriptTag: bool * ?useAssemblyDir: bool -> unit
+    static member WriteStartCode : writer: System.IO.TextWriter * scriptBaseUrl: option<string> * ?includeScriptTag: bool * ?useAssemblyDir: bool -> unit
 
 val AllReferencedAssemblies : Lazy<list<System.Reflection.Assembly>>
 
@@ -80,6 +82,9 @@ and Context =
 
         ///// Gets local resource hash values.
         //GetResourceHash : string * string -> int
+
+        /// Get the base URL path for WebSharper scripts.
+        ScriptBaseUrl : option<string>
 
         /// Constructs URLs to JavaScript-compiled assemblies.
         /// Assembly names are short, such as FSharp.Core.

--- a/src/compiler/WebSharper.Core/Resources.fsi
+++ b/src/compiler/WebSharper.Core/Resources.fsi
@@ -121,6 +121,15 @@ type IDownloadableResource =
     /// Gets the WebSharper output root directory.
     abstract Unpack : string -> unit    
 
+/// An interface for resources whose JavaScript code, if any,
+/// is a sequence of external scripts with the given URLs.
+type IExternalScriptResource =
+    inherit IResource
+
+    /// Get the JavaScript script URL(s) for this resource.
+    /// Can return an empty array if this is not a JavaScript resource.
+    abstract member Urls : Context -> string[]
+
 /// A helper base class for resource-defining types.
 type BaseResource =
 
@@ -141,6 +150,7 @@ type BaseResource =
 
     interface IResource
     interface IDownloadableResource
+    interface IExternalScriptResource
 
 /// Represents the runtime library resource required by all WebSharper code.
 [<Sealed>]

--- a/src/compiler/WebSharper.FSharp/Program.fs
+++ b/src/compiler/WebSharper.FSharp/Program.fs
@@ -223,6 +223,8 @@ let Compile (config : WsConfig) (warnSettings: WarnSettings) =
                 AddExtraAssemblyReferences wsRefs assem
             | _ -> ()
 
+            Bundling.AddExtraBundles config [getRefMeta()] currentMeta sources refs comp assem
+
             PrintWebSharperErrors config.WarnOnly config.ProjectFile comp
             
             if config.PrintJS then

--- a/src/compiler/WebSharper.FSharp/Program.fs
+++ b/src/compiler/WebSharper.FSharp/Program.fs
@@ -214,7 +214,7 @@ let Compile (config : WsConfig) (warnSettings: WarnSettings) =
             Bundling.AddExtraBundles config [getRefMeta()] currentMeta refs comp assem
     
             let js, currentMeta, sources =
-                ModifyAssembly (Some comp) (getRefMeta()) currentMeta config.SourceMap config.AnalyzeClosures assem
+                ModifyAssembly (Some comp) (getRefMeta()) currentMeta config.SourceMap config.AnalyzeClosures config.ScriptBaseUrl assem
 
             match config.ProjectType with
             | Some (Bundle | Website) ->
@@ -257,8 +257,9 @@ let Compile (config : WsConfig) (warnSettings: WarnSettings) =
             match wsRefsMeta.Result with
             | Some (_, metas, _) -> metas
             | _ -> []
+
         let currentJS =
-            lazy CreateBundleJSOutput (getRefMeta()) currentMeta
+            lazy CreateBundleJSOutput (getRefMeta()) currentMeta config.ScriptBaseUrl
         Bundling.Bundle config metas currentMeta comp.JavaScriptExports currentJS sources refs
         TimedStage "Bundling"
         0
@@ -387,6 +388,8 @@ let compileMain argv =
     let wsconfig = Path.Combine(Path.GetDirectoryName (!wsArgs).ProjectFile, "wsconfig.json")
     if File.Exists wsconfig then
         wsArgs := (!wsArgs).AddJson(File.ReadAllText wsconfig)
+
+    wsArgs := SetScriptBaseUrl !wsArgs
 
     let clearOutput() =
         try

--- a/src/compiler/WebSharper.FSharp/Program.fs
+++ b/src/compiler/WebSharper.FSharp/Program.fs
@@ -203,16 +203,21 @@ let Compile (config : WsConfig) (warnSettings: WarnSettings) =
         | Some (_, _, m) -> m 
         | _ -> WebSharper.Core.Metadata.Info.Empty
 
+    let getRefMetas() =
+        match wsRefsMeta.Result with 
+        | Some (_, m, _) -> m 
+        | _ -> []
+
     let js, currentMeta, sources, extraBundles =
         let currentMeta = comp.ToCurrentMetadata(config.WarnOnly)
         if isBundleOnly then
             let currentMeta, sources = TransformMetaSources comp.AssemblyName currentMeta config.SourceMap 
-            let extraBundles = Bundling.AddExtraBundles config [getRefMeta()] currentMeta refs comp (Choice1Of2 comp.AssemblyName)
+            let extraBundles = Bundling.AddExtraBundles config (getRefMetas()) currentMeta refs comp (Choice1Of2 comp.AssemblyName)
             None, currentMeta, sources, extraBundles
         else
             let assem = loader.LoadFile config.AssemblyFile
 
-            let extraBundles = Bundling.AddExtraBundles config [getRefMeta()] currentMeta refs comp (Choice2Of2 assem)
+            let extraBundles = Bundling.AddExtraBundles config (getRefMetas()) currentMeta refs comp (Choice2Of2 assem)
     
             let js, currentMeta, sources =
                 ModifyAssembly (Some comp) (getRefMeta()) currentMeta config.SourceMap config.AnalyzeClosures assem

--- a/src/compiler/WebSharper.FSharp/Program.fs
+++ b/src/compiler/WebSharper.FSharp/Program.fs
@@ -215,7 +215,7 @@ let Compile (config : WsConfig) (warnSettings: WarnSettings) =
             let extraBundles = Bundling.AddExtraBundles config [getRefMeta()] currentMeta refs comp (Choice2Of2 assem)
     
             let js, currentMeta, sources =
-                ModifyAssembly (Some comp) (getRefMeta()) currentMeta config.SourceMap config.AnalyzeClosures config.ScriptBaseUrl assem
+                ModifyAssembly (Some comp) (getRefMeta()) currentMeta config.SourceMap config.AnalyzeClosures assem
 
             match config.ProjectType with
             | Some (Bundle | Website) ->
@@ -260,7 +260,7 @@ let Compile (config : WsConfig) (warnSettings: WarnSettings) =
             | _ -> []
 
         let currentJS =
-            lazy CreateBundleJSOutput (getRefMeta()) currentMeta config.ScriptBaseUrl
+            lazy CreateBundleJSOutput (getRefMeta()) currentMeta
         Bundling.Bundle config metas currentMeta comp currentJS sources refs extraBundles
         TimedStage "Bundling"
         0

--- a/src/compiler/WebSharper.FSharp/Program.fs
+++ b/src/compiler/WebSharper.FSharp/Program.fs
@@ -209,10 +209,12 @@ let Compile (config : WsConfig) (warnSettings: WarnSettings) =
             None, currentMeta, sources
         else
             let assem = loader.LoadFile config.AssemblyFile
+            let currentMeta = comp.ToCurrentMetadata(config.WarnOnly)
+
+            Bundling.AddExtraBundles config [getRefMeta()] currentMeta refs comp assem
     
             let js, currentMeta, sources =
-                ModifyAssembly (Some comp) (getRefMeta()) 
-                    (comp.ToCurrentMetadata(config.WarnOnly)) config.SourceMap config.AnalyzeClosures assem
+                ModifyAssembly (Some comp) (getRefMeta()) currentMeta config.SourceMap config.AnalyzeClosures assem
 
             match config.ProjectType with
             | Some (Bundle | Website) ->
@@ -222,8 +224,6 @@ let Compile (config : WsConfig) (warnSettings: WarnSettings) =
                     | _ -> []
                 AddExtraAssemblyReferences wsRefs assem
             | _ -> ()
-
-            Bundling.AddExtraBundles config [getRefMeta()] currentMeta sources refs comp assem
 
             PrintWebSharperErrors config.WarnOnly config.ProjectFile comp
             

--- a/src/sitelets/WebSharper.Sitelets.Offline/Output.fs
+++ b/src/sitelets/WebSharper.Sitelets.Offline/Output.fs
@@ -254,8 +254,9 @@ let relPath level =
 /// Creates a context for resource HTML printing.
 let resourceContext (st: State) (level: int) : R.Context =
     let relPath = relPath level
+    let scriptsFolder = relPath + "Scripts/"
     let scriptsFile folder file =
-        let url = String.Format("{0}Scripts/{1}/{2}", relPath, folder, file)
+        let url = String.Format("{0}{1}/{2}", scriptsFolder, folder, file)
         R.RenderLink url
     {
         DebuggingEnabled =
@@ -264,6 +265,8 @@ let resourceContext (st: State) (level: int) : R.Context =
             | H.Release -> false
 
         DefaultToHttp = true
+
+        ScriptBaseUrl = Some scriptsFolder
 
         GetSetting = fun _ -> None
 

--- a/src/sitelets/WebSharper.Sitelets.Offline/Output.fs
+++ b/src/sitelets/WebSharper.Sitelets.Offline/Output.fs
@@ -122,11 +122,11 @@ let streamCopy (source: Stream) (target: Stream) =
 type EmbeddedResource =
     {
         Name : string
-        Type : Type
+        AssemblyName : AssemblyName
     }
 
-    static member Create(name, ty) =
-        { Name = name; Type = ty }
+    static member Create(name, asmName) =
+        { Name = name; AssemblyName = asmName }
 
 /// The mutable state of the processing.
 [<Sealed>]
@@ -176,8 +176,7 @@ let getSourceFilePath (conf: Config) (aN: string) (n: string) =
 
 /// Gets the physical path to the embedded resoure file.
 let getEmbeddedResourcePath (conf: Config) (res: EmbeddedResource) =
-    let x = res.Type.Assembly.GetName()
-    P.CreatePath ["Scripts"; x.Name; res.Name]
+    P.CreatePath ["Scripts"; res.AssemblyName.Name; res.Name]
 
 /// Opens a file for writing, taking care to create folders.
 let createFile (cfg: Config) (targetPath: P.Path) =
@@ -239,13 +238,23 @@ let writeResources (aR: AssemblyResolver) (st: State) (sourceMap: bool) (typeScr
             if typeScript then
                 let tp = getAssemblyTypeScriptPath st.Config aN
                 writeEmbeddedResource st.Config aP EMBEDDED_DTS tp
+            st.Metadata.ExtraBundles
+            |> Set.filter (fun b -> b.AssemblyName = aN)
+            |> Set.iter (fun b ->
+                // TODO: this will have to use b.MinifiedFileName
+                // when we get to use .min.js for extra bundles.
+                let filename = b.FileName
+                let res = EmbeddedResource.Create(filename, AssemblyName(b.AssemblyName))
+                let path = getEmbeddedResourcePath st.Config res
+                writeEmbeddedResource st.Config aP filename path
+            )
         | None ->
             stderr.WriteLine("Could not resolve: {0}", aN)
     for res in st.Resources do
         let erp = getEmbeddedResourcePath st.Config res
-        match aR.ResolvePath(AssemblyName res.Type.Assembly.FullName) with
+        match aR.ResolvePath(AssemblyName res.AssemblyName.FullName) with
         | Some aP -> writeEmbeddedResource st.Config aP res.Name erp
-        | None -> stderr.WriteLine("Could not resolve {0}", res.Type.Assembly.FullName)
+        | None -> stderr.WriteLine("Could not resolve {0}", res.AssemblyName.FullName)
 
 /// Generates a relative path prefix, such as "../../../" for level 3.
 let relPath level =
@@ -275,7 +284,7 @@ let resourceContext (st: State) (level: int) : R.Context =
             scriptsFile aN (getAssemblyFileName st.Config.Options.Mode aN)
 
         GetWebResourceRendering = fun ty name ->
-            st.UseResource(EmbeddedResource.Create(name, ty))
+            st.UseResource(EmbeddedResource.Create(name, ty.Assembly.GetName()))
             scriptsFile (ty.Assembly.GetName().Name) name
 
         WebRoot = relPath

--- a/src/sitelets/WebSharper.Sitelets/Content.fs
+++ b/src/sitelets/WebSharper.Sitelets/Content.fs
@@ -87,12 +87,6 @@ module Content =
                 Core.Resources.Rendering.RenderCached(ctx.ResourceContext, r, tw)
         hasResources
 
-    let writeStartScript (tw: HtmlTextWriter) =
-        tw.WriteLine(@"<script type='{0}'>", CT.Text.JavaScript.Text)
-        tw.WriteLine @"if (typeof IntelliFactory !=='undefined')"
-        tw.WriteLine @"  IntelliFactory.Runtime.Start();"
-        tw.WriteLine @"</script>"
-
     type RenderedResources =
         {
             Scripts : string
@@ -121,7 +115,7 @@ module Content =
                 | Core.Resources.Styles -> stylesTw
                 | Core.Resources.Meta -> metaTw)
         if hasResources then
-            writeStartScript scriptsTw
+            scriptsTw.WriteStartCode(ctx.ResourceContext.ScriptBaseUrl)
         {
             Scripts = scriptsW.ToString()
             Styles = stylesW.ToString()
@@ -132,7 +126,7 @@ module Content =
         use w = new StringWriter()
         use tw = new HtmlTextWriter(w, " ")
         let hasResources = writeResources ctx controls (fun _ -> tw)
-        if hasResources then writeStartScript tw
+        if hasResources then tw.WriteStartCode(ctx.ResourceContext.ScriptBaseUrl)
         w.ToString()
 
     let toCustomContentAsync (genPage: Context<'T> -> Async<Page>) context : Async<Http.Response> =
@@ -144,7 +138,7 @@ module Content =
                     let hasResources = writeResources context body (fun _ -> tw)
                     for elem in htmlPage.Head do
                         elem.Write(context, tw)
-                    if hasResources then writeStartScript tw
+                    if hasResources then tw.WriteStartCode(context.ResourceContext.ScriptBaseUrl)
                 let renderBody (tw: HtmlTextWriter) =
                     for elem in body do
                         elem.Write(context, tw)

--- a/src/sitelets/WebSharper.Web/ResourceContext.fs
+++ b/src/sitelets/WebSharper.Web/ResourceContext.fs
@@ -21,7 +21,7 @@ module ResourceContext =
             {
                 DebuggingEnabled = isDebug
                 DefaultToHttp = false
-                ScriptBaseUrl = Some pu.ScriptBasePath
+                ScriptBaseUrl = Some (pu.ScriptBasePath + "/")
                 GetSetting = Context.GetSetting
                 GetAssemblyRendering = fun name ->
                     let aid = P.AssemblyId.Create(name)

--- a/src/sitelets/WebSharper.Web/ResourceContext.fs
+++ b/src/sitelets/WebSharper.Web/ResourceContext.fs
@@ -21,6 +21,7 @@ module ResourceContext =
             {
                 DebuggingEnabled = isDebug
                 DefaultToHttp = false
+                ScriptBaseUrl = Some pu.ScriptBasePath
                 GetSetting = Context.GetSetting
                 GetAssemblyRendering = fun name ->
                     let aid = P.AssemblyId.Create(name)

--- a/src/sitelets/WebSharper.Web/ScriptManager.fs
+++ b/src/sitelets/WebSharper.Web/ScriptManager.fs
@@ -91,10 +91,7 @@ type ScriptManager() =
                 WebSharper.Activator.META_ID, encode content)
             resources |> Seq.iter (fun r -> Re.Rendering.RenderCached(ctx, r, (fun _ -> writer)))
             writer.WriteLine()
-            writer.WriteLine("<script type='{0}'>", CT.Text.JavaScript.Text)
-            writer.WriteLine @"if (typeof IntelliFactory !=='undefined')"
-            writer.WriteLine @"  IntelliFactory.Runtime.Start();"
-            writer.WriteLine("</script>")
+            writer.WriteStartCode(ctx.ScriptBaseUrl)
 
     /// Searches the page for a ScriptManager.
     static member private TryFind(page: System.Web.UI.Page) =

--- a/src/stdlib/WebSharper.JavaScript/Html5.fs
+++ b/src/stdlib/WebSharper.JavaScript/Html5.fs
@@ -550,7 +550,7 @@ module File =
         Class "Blob"
         |+> Static [
                 Constructor T<unit>
-                Constructor ((Type.ArrayOf TypedArrays.ArrayBuffer + Type.ArrayOf TypedArrays.ArrayBufferView + TSelf + T<string>) * !?BlobPropertyBag)
+                Constructor ((Type.ArrayOf TypedArrays.ArrayBuffer + Type.ArrayOf TypedArrays.ArrayBufferView + Type.ArrayOf TSelf + Type.ArrayOf T<string>) * !?BlobPropertyBag)
             ]
         |+> Instance [
                 "size" =? T<int>
@@ -1709,6 +1709,8 @@ module WebWorkers =
         |=> Implements [AbstractWorker]
         |+> Static [
             Constructor (T<string>?url * !?WorkerOptions)
+            Constructor (DedicatedWorkerGlobalScope ^-> T<unit>)
+            |> WithMacro typeof<WebSharper.Core.Macros.WebWorker>
         ]
         |+> Instance [
             "onmessage" =@ General.MessageEvent ^-> T<unit>

--- a/src/stdlib/WebSharper.JavaScript/Html5.fs
+++ b/src/stdlib/WebSharper.JavaScript/Html5.fs
@@ -1711,6 +1711,12 @@ module WebWorkers =
             Constructor (T<string>?url * !?WorkerOptions)
             Constructor (DedicatedWorkerGlobalScope ^-> T<unit>)
             |> WithMacro typeof<WebSharper.Core.Macros.WebWorker>
+            |> WithComment "Create a Web Worker with the given expression as entry point. \
+                A bundled JavaScript file named <assemblyname>.worker.js is automatically compiled for it."
+            Constructor (T<string>?name * (DedicatedWorkerGlobalScope ^-> T<unit>))
+            |> WithMacro typeof<WebSharper.Core.Macros.WebWorker>
+            |> WithComment "Create a Web Worker with the given expression as entry point. \
+                A bundled JavaScript file named <assemblyname>.<name>.js is automatically compiled for it."
         ]
         |+> Instance [
             "onmessage" =@ General.MessageEvent ^-> T<unit>

--- a/tests/WebSharper.Html5.Tests/Tests.fs
+++ b/tests/WebSharper.Html5.Tests/Tests.fs
@@ -473,6 +473,18 @@ let WebWorkerTests =
             equal res "The worker replied: [worker2] Hello world!"
         }
 
+        Test "Macro with custom name" {
+            let worker = new Worker("my-worker", fun self ->
+                self.Onmessage <- fun e ->
+                    self.PostMessage(GlobalFunction(As<string> e.Data))
+            )
+            let! res = AsyncContinuationTimeout "Worker didn't run" <| fun ok ->
+                worker.Onmessage <- fun e ->
+                    ok ("The worker replied: " + As<string> e.Data)
+                worker.PostMessage "Hello world!"
+            equal res "The worker replied: [worker] Hello world!"
+        }
+
         //Test "Macro with nested worker" {
         //    let worker = new Worker(InnerWorker)
         //    let err = "Nested worker didn't run (This is expected on Chrome! Should work on Firefox)"

--- a/tests/WebSharper.Html5.Tests/Tests.fs
+++ b/tests/WebSharper.Html5.Tests/Tests.fs
@@ -486,10 +486,6 @@ let WebWorkerTests =
         Test "With Dependencies" {
             let worker = new Worker(fun self ->
                 self.Onmessage <- fun e ->
-                    // Works:
-                    //self.PostMessage(MathJS.Math.Create().Abs(e.Data :?> int))
-
-                    // Fails:
                     MathJS.Math.Create().Abs(e.Data :?> int) |> self.PostMessage
             )
             let! res = AsyncContinuationTimeout "Worker didn't run" <| fun ok ->

--- a/tests/WebSharper.Html5.Tests/Tests.fs
+++ b/tests/WebSharper.Html5.Tests/Tests.fs
@@ -400,6 +400,10 @@ let GlobalFunction(s: string) =
     "[worker] " + s
 
 [<JavaScript>]
+let GlobalFunction2(s: string) =
+    "[worker2] " + s
+
+[<JavaScript>]
 let WebWorkerTests =
     TestCategory "Web Workers" {
 
@@ -424,6 +428,16 @@ let WebWorkerTests =
                     ok ("The worker replied: " + As<string> e.Data)
                 worker.PostMessage "Hello world!"
             equal res "The worker replied: [worker] Hello world!"
+
+            let worker2 = new Worker(fun self ->
+                self.Onmessage <- fun e ->
+                    self.PostMessage(GlobalFunction2(As<string> e.Data))
+            )
+            let! res = Async.FromContinuations <| fun (ok, _, _) ->
+                worker.Onmessage <- fun e ->
+                    ok ("The worker replied: " + As<string> e.Data)
+                worker.PostMessage "Hello world!"
+            equal res "The worker replied: [worker2] Hello world!"
         }
 
     }

--- a/tests/WebSharper.Html5.Tests/Tests.fs
+++ b/tests/WebSharper.Html5.Tests/Tests.fs
@@ -474,15 +474,15 @@ let WebWorkerTests =
             equal res "The worker replied: [worker2] Hello world!"
         }
 
-        Test "Macro with nested worker" {
-            let worker = new Worker(InnerWorker)
-            let err = "Nested worker didn't run (This is expected on Chrome! Should work on Firefox)"
-            let! res = AsyncContinuationTimeout err <| fun ok ->
-                worker.Onmessage <- fun e ->
-                    ok ("The worker replied: " + As<string> e.Data)
-                worker.PostMessage "Hello world!"
-            equal res "The worker replied: [worker2] Hello world!"
-        }
+        //Test "Macro with nested worker" {
+        //    let worker = new Worker(InnerWorker)
+        //    let err = "Nested worker didn't run (This is expected on Chrome! Should work on Firefox)"
+        //    let! res = AsyncContinuationTimeout err <| fun ok ->
+        //        worker.Onmessage <- fun e ->
+        //            ok ("The worker replied: " + As<string> e.Data)
+        //        worker.PostMessage "Hello world!"
+        //    equal res "The worker replied: [worker2] Hello world!"
+        //}
 
     }
 

--- a/tests/WebSharper.Html5.Tests/Tests.fs
+++ b/tests/WebSharper.Html5.Tests/Tests.fs
@@ -434,9 +434,9 @@ let WebWorkerTests =
                     self.PostMessage(GlobalFunction2(As<string> e.Data))
             )
             let! res = Async.FromContinuations <| fun (ok, _, _) ->
-                worker.Onmessage <- fun e ->
+                worker2.Onmessage <- fun e ->
                     ok ("The worker replied: " + As<string> e.Data)
-                worker.PostMessage "Hello world!"
+                worker2.PostMessage "Hello world!"
             equal res "The worker replied: [worker2] Hello world!"
         }
 

--- a/tests/WebSharper.Html5.Tests/WebSharper.Html5.Tests.fsproj
+++ b/tests/WebSharper.Html5.Tests/WebSharper.Html5.Tests.fsproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\..\src\stdlib\WebSharper.JavaScript\WebSharper.JavaScript.fsproj" />
     <ProjectReference Include="..\..\src\stdlib\WebSharper.JQuery\WebSharper.JQuery.fsproj" />
     <ProjectReference Include="..\..\src\stdlib\WebSharper.Main\WebSharper.Main.fsproj" />
+    <ProjectReference Include="..\..\src\stdlib\WebSharper.MathJS\WebSharper.MathJS.fsproj" />
     <ProjectReference Include="..\..\src\stdlib\WebSharper.Testing\WebSharper.Testing.fsproj" />
   </ItemGroup>
   <Import Project="..\..\msbuild\WebSharper.FSharp.Internal.targets" />

--- a/tests/WebSharper.SPA.Tests/wsconfig.json
+++ b/tests/WebSharper.SPA.Tests/wsconfig.json
@@ -1,4 +1,5 @@
 {
   "Project": "BundleOnly",
-  "OutputDir": "Content"
+  "OutputDir": "Content",
+  "DownloadResources": true
 }

--- a/tools/GenSingleFw.fsx
+++ b/tools/GenSingleFw.fsx
@@ -60,8 +60,9 @@ let copyAndTransformProjects (srcDir: string) (dstDir: string) (transformTargetF
         let fn = Path.GetFileName(f)
         Directory.CreateDirectory(dstFullDir) |> ignore
         copyFileIfExistsAndIsDifferent (origFullDir +/ "paket.references") dstFullDir
-        if not (f.Contains("SPA")) then
-            copyFileIfExistsAndIsDifferent (origFullDir +/ "wsconfig.json") dstFullDir
+        copyFileIfExistsAndIsDifferent (origFullDir +/ "wsconfig.json") dstFullDir
+        copyFileIfExistsAndIsDifferent (origFullDir +/ "index.html") dstFullDir
+        copyFileIfExistsAndIsDifferent (origFullDir +/ "Web.config") dstFullDir
         let doc = XDocument.Load(f)
 
         // Fix target framework


### PR DESCRIPTION
[WIP] #970 

Still todo:

* [x] Add `ICompilation.AddBundle(name, expression)` which creates a resource that bundles the given expression. If a resource with this name exists in this assembly, it is suffixed with a number.
* [x] Add the expression's dependencies to this bundle.
* [x] Add macro `Worker` constructor that uses `AddBundle`.
* [x] Add `IntelliFactory.Runtime.ScriptPath(assemblyName, scriptFile)` to allow the `Worker` macro to retrieve the path to the requested script.
* [x] Add a compilation parameter `scriptBaseUrl` used by `ScriptPath`. This is set by default to `/Scripts/WebSharper/` for runtime sitelets, `/Scripts/` for Html sitelets and `/Content/` for SPAs.
* [x] Extract worker scripts when in SPA mode.
* [x] Always include main assembly script in sitelet output if a worker is called, so that `scriptBaseUrl` is set.
* [x] Import external `BaseResource`s with `importScripts()`.
* [ ] Ensure that one can create a Worker from a Worker. This will probably involve setting the `scriptBaseUrl` in Worker bundles too.
