### PR TITLE
Update WebSharperCompile target to incrementally build (#882)

### DIFF
--- a/msbuild/WebSharper.CSharp.targets
+++ b/msbuild/WebSharper.CSharp.targets
@@ -31,7 +31,7 @@
     <ZafirToolPath Condition=" '$(ZafirToolPath)' == '' AND '$(_WebSharperUseNetFxCompiler)' != 'True' AND '$(OS)' != 'Windows_NT' ">$(MSBuildThisFileDirectory)/../tools/netstandard2.0/zafircs-netcore.sh</ZafirToolPath>
   </PropertyGroup>
   <UsingTask AssemblyFile="$(WebSharperTaskAssembly)" TaskName="WebSharper.MSBuild.CSharp.WebSharperTask" />
-  <Target Name="WebSharperCompile" AfterTargets="CoreCompile">
+  <Target Name="WebSharperCompile" AfterTargets="CoreCompile" Inputs="@(Compile)" Outputs="$(TargetPath)">
     <Exec Command="chmod u+x '$(ZafirToolPath)'" Condition="'$(OS)' != 'Windows_NT'" />
     <WebSharperTask 
       DefineConstants="$(DefineConstants)"


### PR DESCRIPTION
This is for issue #882 

This change adds "Inputs" and "Outputs" attributes to the target element so that
msbuild can determine if the target can be skipped when the files are
up-to-date.

+ The inputs are the source files specified in the "Compile" items
+ The output is the the output dll, referenced through the
"TargetPath" property.

TargetPath is the absolute path name of the primary output file for
the build (defined as drive + path + base name + file extension).