### PR TITLE
Add QuotationCompiler helper class

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -27,9 +27,15 @@
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
-    
+
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT' ">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
+
+    <!-- Disable automagic references for F# DotNet SDK -->
+    <!-- This will not do anything for other project types -->
+    <!-- see https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1002-fsharp-in-dotnet-sdk.md -->
+    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
+    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
 
     <!-- Disable Paket restore under NCrunch build -->
     <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
@@ -130,7 +136,7 @@
         <!-- Parse our simple 'paket.restore.cached' json ...-->
         <PaketRestoreCachedSplitObject Include="$([System.Text.RegularExpressions.Regex]::Split(`$(PaketRestoreCachedContents)`, `{|}|,`))"></PaketRestoreCachedSplitObject>
         <!-- Keep Key, Value ItemGroup-->
-        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)" 
+        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)"
             Condition=" $([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `&quot;: &quot;`).Length) &gt; 1 ">
           <Key>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[0].Replace(`"`, ``).Replace(` `, ``))</Key>
           <Value>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[1].Replace(`"`, ``).Replace(` `, ``))</Value>
@@ -163,7 +169,7 @@
     <Exec Command='$(PaketBootStrapperCommand)' Condition=" '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
     <Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we need a full restore (hashes don't match)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true'" />
     <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true' " ContinueOnError="false" />
-    
+
     <!-- Step 2 Detect project specific changes -->
     <ItemGroup>
       <MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>

--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -27,15 +27,9 @@
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
-
+    
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT' ">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
-
-    <!-- Disable automagic references for F# DotNet SDK -->
-    <!-- This will not do anything for other project types -->
-    <!-- see https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1002-fsharp-in-dotnet-sdk.md -->
-    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
-    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
 
     <!-- Disable Paket restore under NCrunch build -->
     <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
@@ -136,7 +130,7 @@
         <!-- Parse our simple 'paket.restore.cached' json ...-->
         <PaketRestoreCachedSplitObject Include="$([System.Text.RegularExpressions.Regex]::Split(`$(PaketRestoreCachedContents)`, `{|}|,`))"></PaketRestoreCachedSplitObject>
         <!-- Keep Key, Value ItemGroup-->
-        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)"
+        <PaketRestoreCachedKeyValue Include="@(PaketRestoreCachedSplitObject)" 
             Condition=" $([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `&quot;: &quot;`).Length) &gt; 1 ">
           <Key>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[0].Replace(`"`, ``).Replace(` `, ``))</Key>
           <Value>$([System.Text.RegularExpressions.Regex]::Split(`%(Identity)`, `": "`)[1].Replace(`"`, ``).Replace(` `, ``))</Value>
@@ -169,7 +163,7 @@
     <Exec Command='$(PaketBootStrapperCommand)' Condition=" '$(PaketBootstrapperStyle)' == 'classic' AND Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
     <Error Text="Stop build because of PAKET_ERROR_ON_MSBUILD_EXEC and we need a full restore (hashes don't match)" Condition=" '$(PAKET_ERROR_ON_MSBUILD_EXEC)' == 'true' AND '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true'" />
     <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(PaketDisableGlobalRestore)' != 'true' " ContinueOnError="false" />
-
+    
     <!-- Step 2 Detect project specific changes -->
     <ItemGroup>
       <MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>

--- a/src/compiler/WebSharper.Compiler/Compilation.fs
+++ b/src/compiler/WebSharper.Compiler/Compilation.fs
@@ -144,6 +144,14 @@ type Compilation(meta: Info, ?hasGraph) =
 
     member this.Errors = List.ofSeq errors
 
+    member this.SetErrors(e) =
+        errors.Clear()
+        errors.AddRange(e)
+
+    member this.SetWarnings(w) =
+        warnings.Clear()
+        warnings.AddRange(w)
+
     member this.AddWarning (pos : SourcePos option, warning : CompilationWarning) =
         warnings.Add (pos, warning)
 

--- a/src/compiler/WebSharper.Compiler/Compilation.fs
+++ b/src/compiler/WebSharper.Compiler/Compilation.fs
@@ -82,6 +82,7 @@ type Compilation(meta: Info, ?hasGraph) =
         typ.Value.FullName.Split('.', '+') |> List.ofArray |> List.map removeGen |> List.rev 
 
     member val UseLocalMacros = true with get, set
+    member val UseReflectedDefinitions = false with get, set
     member val SingleNoJSErrors = false with get, set
     member val SiteletDefinition: option<TypeDefinition> = None with get, set
     member val AssemblyName = "EntryPoint" with get, set
@@ -605,32 +606,45 @@ type Compilation(meta: Info, ?hasGraph) =
                             List.foldBack (fun (m, p) fb -> Some (Macro (m, p, fb))) cls.Macros None |> Option.get
                         Compiled (info, Optimizations.None, Undefined)
                     else
-                        match this.GetCustomType typ with
-                        | NotCustomType -> 
-                            let mName = meth.Value.MethodName
-                            let candidates = 
-                                [
-                                    for m in cls.Methods.Keys do
-                                        if m.Value.MethodName = mName then
-                                            yield m
-                                    for t, m in compilingMethods.Keys do
-                                        if typ = t && m.Value.MethodName = mName then
-                                            yield m
-                                ]
-                            if List.isEmpty candidates then
-                                let names =
-                                    seq {
+                        let reflected =
+                            if this.UseReflectedDefinitions then
+                                let mi = Reflection.LoadMethod typ meth     
+                                match WebSharper.Compiler.ReflectedDefinitionReader.readReflected this mi with
+                                | Some rd ->
+                                    Some ()
+                                | None ->
+                                    None
+                            else 
+                                None
+                        match reflected with
+                        | Some m -> Compiling m
+                        | None ->
+                            match this.GetCustomType typ with
+                            | NotCustomType -> 
+                                let mName = meth.Value.MethodName
+                                let candidates = 
+                                    [
                                         for m in cls.Methods.Keys do
-                                            yield m.Value.MethodName
+                                            if m.Value.MethodName = mName then
+                                                yield m
                                         for t, m in compilingMethods.Keys do
-                                            if typ = t then
+                                            if typ = t && m.Value.MethodName = mName then
+                                                yield m
+                                    ]
+                                if List.isEmpty candidates then
+                                    let names =
+                                        seq {
+                                            for m in cls.Methods.Keys do
                                                 yield m.Value.MethodName
-                                    }
-                                    |> Seq.distinct |> List.ofSeq
-                                LookupMemberError (MethodNameNotFound (typ, meth, names))
-                            else
-                                LookupMemberError (MethodNotFound (typ, meth, candidates))
-                        | i -> CustomTypeMember i
+                                            for t, m in compilingMethods.Keys do
+                                                if typ = t then
+                                                    yield m.Value.MethodName
+                                        }
+                                        |> Seq.distinct |> List.ofSeq
+                                    LookupMemberError (MethodNameNotFound (typ, meth, names))
+                                else
+                                    LookupMemberError (MethodNotFound (typ, meth, candidates))
+                            | i -> CustomTypeMember i
         | _ ->
             match this.GetCustomType typ with
             | NotCustomType -> LookupMemberError (TypeNotFound typ)

--- a/src/compiler/WebSharper.Compiler/QuotationCompiler.fs
+++ b/src/compiler/WebSharper.Compiler/QuotationCompiler.fs
@@ -149,17 +149,19 @@ type QuotationCompiler (?meta : M.Info) =
                     }
                 )
                 
-    member this.Compile (expr: Expr) = 
-        let e = QuotationReader.readExpression comp expr
-        let trE = Translator.DotNetToJavaScript.CompileExpression(comp, e)
-        let js = JavaScriptWriter.transformExpr (JavaScriptWriter.Environment.New(WebSharper.Core.JavaScript.Preferences.Readable)) trE
-        trE, js
+    //member this.Compile (expr: Expr) = 
+    //    let e = QuotationReader.readExpression comp expr
+    //    let trE = Translator.DotNetToJavaScript.CompileExpression(comp, e)
+    //    let js = JavaScriptWriter.transformExpr (JavaScriptWriter.Environment.New(WebSharper.Core.JavaScript.Preferences.Readable)) trE
+    //    trE, js
 
     member this.CompileToJSAndRefs (expr: Expr, prefs: WebSharper.Core.JavaScript.Preferences) =
         let e = QuotationReader.readExpression comp expr
-        let trE, node = Translator.DotNetToJavaScript.TransformExpressionWithDeps(comp, e)
+        let ep, node = Translator.DotNetToJavaScript.CompileExpressionWithDeps(comp, e)
+        let p =
+            Packager.packageAssembly meta (comp.ToCurrentMetadata()) (Some ep) Packager.ForceImmediate
         let js =
-            trE
+            p
             |> JavaScriptWriter.transformExpr (JavaScriptWriter.Environment.New(prefs))
             |> WebSharper.Core.JavaScript.Writer.ExpressionToString prefs 
         let deps =

--- a/src/compiler/WebSharper.Compiler/QuotationCompiler.fs
+++ b/src/compiler/WebSharper.Compiler/QuotationCompiler.fs
@@ -1,0 +1,44 @@
+// $begin{copyright}
+//
+// This file is part of WebSharper
+//
+// Copyright (c) 2008-2018 IntelliFactory
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// $end{copyright}
+
+// Reads F# quotations as WebSharper.Core.AST 
+namespace WebSharper.Compiler
+
+open FSharp.Quotations
+
+open WebSharper.Core
+open WebSharper.Core.AST
+
+module M = WebSharper.Core.Metadata
+
+type QuotationCompiler (?meta : M.Info) =
+    let meta = defaultArg meta M.Info.Empty
+    let comp = Compilation(meta)
+
+    member this.Compilation = comp
+
+    member this.CompileReflectedDefinitions() =
+            
+
+
+    member this.Compile (expr: Expr) = 
+        let e = QuotationReader.readExpression comp expr
+        Translator.
+        ()

--- a/src/compiler/WebSharper.Compiler/QuotationCompiler.fs
+++ b/src/compiler/WebSharper.Compiler/QuotationCompiler.fs
@@ -25,8 +25,10 @@ open FSharp.Quotations
 
 open WebSharper.Core
 open WebSharper.Core.AST
+open System.Reflection
 
 module M = WebSharper.Core.Metadata
+type FST = FSharp.Reflection.FSharpType
 
 type QuotationCompiler (?meta : M.Info) =
     let meta = defaultArg meta M.Info.Empty
@@ -34,9 +36,80 @@ type QuotationCompiler (?meta : M.Info) =
 
     member this.Compilation = comp
 
-    member this.CompileReflectedDefinitions() =
-            
+    member this.CompileReflectedDefinitions(asm: Assembly) =
+        for t in asm.GetTypes() do
+            let typeAnnot =
+                lazy AttributeReader.attrReader.GetTypeAnnot(AttributeReader.TypeAnnotation.Empty, t.CustomAttributes)
+            let clsMembers = ResizeArray()
+            let readMember m =
+                match ReflectedDefinitionReader.readReflected comp m with
+                | Some expr ->
+                    let mAnnot = AttributeReader.attrReader.GetMemberAnnot(typeAnnot.Value, m.CustomAttributes)   
+                    let mem = Reflection.ReadMember m |> Option.get
+                    clsMembers.Add(NotResolvedMember.Method(mem, ))
+                | None ->
+                    ()
+            for m in t.GetMethods() do
+                readMember m
 
+            if clsMembers.Count > 0 then
+
+                let annot = typeAnnot.Value
+
+                let thisDef = Reflection.ReadTypeDefinition(t) 
+                
+                let def =
+                    match annot.ProxyOf with
+                    | Some p -> p
+                    | _ -> thisDef
+
+                let fsharpSpecificNonException =
+                    FST.IsUnion(t) || FST.IsRecord(t) || t.IsValueType
+
+                let fsharpSpecific = 
+                    fsharpSpecificNonException || FST.IsExceptionRepresentation(t)
+
+                let fsharpModule = FST.IsModule(t)
+
+                let baseCls =
+                    if fsharpSpecificNonException || fsharpModule || t.IsValueType || annot.IsStub || def.Value.FullName = "System.Object" then
+                        None
+                    elif annot.Prototype = Some false then
+                        t.BaseType |> Option.ofObj |> Option.bind (fun bt -> Reflection.ReadTypeDefinition(bt) |> ignoreSystemObject)
+                    else 
+                        t.BaseType|> Option.ofObj |> Option.map (fun bt -> Reflection.ReadTypeDefinition(bt))
+
+                let strongName =
+                    annot.Name |> Option.map (fun n ->
+                        if n.StartsWith "." then n.TrimStart('.') else
+                        if n.Contains "." then n else 
+                            let origName = thisDef.Value.FullName
+                            origName.[.. origName.LastIndexOf '.'] + n
+                    )   
+
+                let ckind = 
+                    if annot.IsStub || (hasStubMember && not hasNonStubMember)
+                    then NotResolvedClassKind.Stub
+                    elif fsharpModule then NotResolvedClassKind.Static
+                    elif (annot.IsJavaScript && (isAbstractClass cls || cls.IsFSharpExceptionDeclaration)) || (annot.Prototype = Some true)
+                    then NotResolvedClassKind.WithPrototype
+                    else NotResolvedClassKind.Class
+
+                comp.AddClass(
+                    def,
+                    {
+                        StrongName = strongName
+                        BaseClass = baseCls
+                        Requires = annot.Requires
+                        Members = List.ofSeq clsMembers
+                        Kind = ckind
+                        IsProxy = Option.isSome annot.ProxyOf
+                        Macros = annot.Macros
+                        ForceNoPrototype = (annot.Prototype = Some false) || hasConstantCase
+                        ForceAddress = hasSingletonCase || def.Value.FullName = "System.Exception" // needed for Error inheritance
+                    }
+                )
+                
 
     member this.Compile (expr: Expr) = 
         let e = QuotationReader.readExpression comp expr

--- a/src/compiler/WebSharper.Compiler/QuotationCompiler.fs
+++ b/src/compiler/WebSharper.Compiler/QuotationCompiler.fs
@@ -160,10 +160,8 @@ type QuotationCompiler (?meta : M.Info) =
         let ep, node = Translator.DotNetToJavaScript.CompileExpressionWithDeps(comp, e)
         let p =
             Packager.packageAssembly meta (comp.ToCurrentMetadata()) (Some ep) Packager.ForceImmediate
-        let js =
-            p
-            |> JavaScriptWriter.transformExpr (JavaScriptWriter.Environment.New(prefs))
-            |> WebSharper.Core.JavaScript.Writer.ExpressionToString prefs 
+        let js, _ =
+            p |> Packager.exprToString prefs (fun () -> WebSharper.Core.JavaScript.Writer.CodeWriter())
         let deps =
             comp.Graph.GetResources [ node ]
 

--- a/src/compiler/WebSharper.Compiler/QuotationReader.fs
+++ b/src/compiler/WebSharper.Compiler/QuotationReader.fs
@@ -25,6 +25,7 @@ open FSharp.Quotations
 
 open WebSharper.Core
 open WebSharper.Core.AST
+open WebSharper.Core.Metadata
 
 module A = WebSharper.Compiler.AttributeReader
 
@@ -37,7 +38,7 @@ type Environment =
     {
         Vars : System.Collections.Generic.Dictionary<Var, Id * VarKind>
         Exception : option<Id>
-        Compilation : Compilation
+        Compilation : ICompilation
     }
     static member New(comp) = 
         { 
@@ -269,7 +270,7 @@ let rec transformExpression (env: Environment) (expr: Expr) =
             match e with
             | ParseError m -> m
             | _ -> "Error while reading F# quotation: " + e.Message //+ " " + e.StackTrace
-        env.Compilation.AddError(getOptSourcePos expr, SourceError msg)
+        env.Compilation.AddError(getOptSourcePos expr, msg)
         CompilationHelpers.errorPlaceholder        
 
 let readExpression (comp: Compilation) expr =

--- a/src/compiler/WebSharper.Compiler/QuotationReader.fs
+++ b/src/compiler/WebSharper.Compiler/QuotationReader.fs
@@ -273,5 +273,5 @@ let rec transformExpression (env: Environment) (expr: Expr) =
         env.Compilation.AddError(getOptSourcePos expr, msg)
         CompilationHelpers.errorPlaceholder        
 
-let readExpression (comp: Compilation) expr =
+let readExpression (comp: ICompilation) expr =
     transformExpression (Environment.New(comp)) expr

--- a/src/compiler/WebSharper.Compiler/ReflectedDefinitionReader.fs
+++ b/src/compiler/WebSharper.Compiler/ReflectedDefinitionReader.fs
@@ -23,11 +23,13 @@ module WebSharper.Compiler.ReflectedDefinitionReader
 
 open System.Reflection
 open FSharp.Quotations
+open FSharp.Reflection
 open WebSharper.Core.AST
 open WebSharper.Core.Metadata
 
 module A = WebSharper.Compiler.AttributeReader
 module QR = WebSharper.Compiler.QuotationReader
+
 
 let readReflected (comp: ICompilation) (m: MethodBase) =
     match Expr.TryGetReflectedDefinition m with
@@ -41,16 +43,18 @@ let readReflected (comp: ICompilation) (m: MethodBase) =
                 |> Seq.map (fun v -> v.Value :?> int) |> List.ofSeq |> Some
             else None  
         )
-    let currying =
+    let currying, curryingInfo =
         match compArgCounts with
         | None ->
             let k = m.GetParameters().Length
             // -1 marks 'this' argument
-            if m.IsStatic then 
-                if k = 0 then [1] else [k]
-            elif k = 0 then [-1; 1] else [-1; k]
+            if FSharpType.IsModule m.DeclaringType && m.Name.StartsWith "get_" then
+                [], "Module let"
+            elif m.IsStatic || m.IsConstructor then 
+                if k = 0 then [1], "Static 0" else [k], "Static " + string k
+            elif k = 0 then [-1; 1], "Instance 0" else [-1; k], "Instance " + string k
         | Some x ->
-            if m.IsStatic then x else -1 :: x   
+            if m.IsStatic || m.IsConstructor then x, "CompArg Static " + string x else -1 :: x, "CompArg Instance " + string x   
     
     let env = QR.Environment.New(comp)
     
@@ -63,7 +67,7 @@ let readReflected (comp: ICompilation) (m: MethodBase) =
                 env.AddVar(i, arg, QR.ThisArg)
                 decurry [] restCurr body
             | _ ->
-                failwithf "Expecting a lambda while decurrying 'this' argument of a ReflectedDefinition quotation: %A" expr
+                failwithf "Expecting a lambda while decurrying 'this' argument of a ReflectedDefinition quotation: %A currying info %A" expr curryingInfo
         | 1 :: restCurr ->
             match expr with
             | Patterns.Lambda (arg, body) ->
@@ -71,7 +75,7 @@ let readReflected (comp: ICompilation) (m: MethodBase) =
                 env.AddVar(i, arg, QR.LocalVar)
                 decurry (args @ [i]) restCurr body
             | _ ->
-                failwithf "Expecting a lambda while decurrying an argument of a ReflectedDefinition quotation: %A" expr
+                failwithf "Expecting a lambda while decurrying an argument of a ReflectedDefinition quotation: %A currying info %A" expr curryingInfo
         | k :: restCurr ->
             match expr with
             | Patterns.Lambda (arg, body) ->
@@ -84,7 +88,7 @@ let readReflected (comp: ICompilation) (m: MethodBase) =
                         else
                             detuple (vn :: tup) (j + 1) q
                     | _ ->
-                        failwithf "Expecting a tuple get while detupling arguments a ReflectedDefinition quotation: %A" q
+                        failwithf "Expecting a tuple get while detupling arguments a ReflectedDefinition quotation: %A currying info %A" q curryingInfo
                 
                 let tupleVars, detupledBody = detuple [] 0 body
                 let tupleArgs = 
@@ -95,7 +99,7 @@ let readReflected (comp: ICompilation) (m: MethodBase) =
                     ) 
                 decurry (args @ tupleArgs) restCurr detupledBody
             | _ ->
-                failwithf "Expecting a lambda while detupling arguments a ReflectedDefinition quotation: %A" expr
+                failwithf "Expecting a lambda while detupling arguments a ReflectedDefinition quotation: %A currying info %A" expr curryingInfo
         | _ ->
             Lambda(args, QR.transformExpression env expr)
 

--- a/src/compiler/WebSharper.Compiler/ReflectedDefinitionReader.fs
+++ b/src/compiler/WebSharper.Compiler/ReflectedDefinitionReader.fs
@@ -24,11 +24,12 @@ module WebSharper.Compiler.ReflectedDefinitionReader
 open System.Reflection
 open FSharp.Quotations
 open WebSharper.Core.AST
+open WebSharper.Core.Metadata
 
 module A = WebSharper.Compiler.AttributeReader
 module QR = WebSharper.Compiler.QuotationReader
 
-let readReflected (comp: Compilation) (m: MethodBase) =
+let readReflected (comp: ICompilation) (m: MethodBase) =
     match Expr.TryGetReflectedDefinition m with
     | None -> None
     | Some q -> 

--- a/src/compiler/WebSharper.Compiler/Translator.fs
+++ b/src/compiler/WebSharper.Compiler/Translator.fs
@@ -723,18 +723,16 @@ type DotNetToJavaScript private (comp: Compilation, ?inProgress) =
         comp.CloseMacros()
         compileMethods()
 
-    member this.TransformExpressionWithDeps(expr) =
-        let node = M.ExtraBundleEntryPointNode ("Expr", System.Guid.NewGuid().ToString())
-        currentNode <- node
-        let wrap e = ExprStatement(ItemSet(Global [], Value (String "EntryPoint"), Lambda([], e)))
-        let res = this.TransformExpression(expr) |> wrap |> breakStatement
-        res, node
+    member this.TransformExpressionWithNode(expr, node) =
+        match node with
+        | Some n ->
+            currentNode <- n
+        | _ ->
+            currentNode <- M.ExtraBundleEntryPointNode ("Expr", System.Guid.NewGuid().ToString()) // unique new node
+        this.TransformExpression(expr) |> breakExpr
     
-    static member CompileExpression (comp, expr) =
-        DotNetToJavaScript(comp).TransformExpressionWithDeps(expr) |> fst
-
-    static member CompileExpressionWithDeps (comp, expr) =
-        DotNetToJavaScript(comp).TransformExpressionWithDeps(expr)
+    static member CompileExpression (comp, expr, ?node) =
+        DotNetToJavaScript(comp).TransformExpressionWithNode(expr, node)
 
     member this.AnotherNode() = DotNetToJavaScript(comp, currentNode :: inProgress)    
 

--- a/src/compiler/WebSharper.Compiler/Translator.fs
+++ b/src/compiler/WebSharper.Compiler/Translator.fs
@@ -723,8 +723,17 @@ type DotNetToJavaScript private (comp: Compilation, ?inProgress) =
         comp.CloseMacros()
         compileMethods()
 
+    member this.TransformExpressionWithDeps(expr) =
+        let node = M.ExtraBundleEntryPointNode ("Expr", System.Guid.NewGuid().ToString())
+        currentNode <- node
+        let res = this.TransformExpression(expr)
+        res, node
+    
     static member CompileExpression (comp, expr) =
-        DotNetToJavaScript(comp).TransformExpression(expr)
+        DotNetToJavaScript(comp).TransformExpressionWithDeps(expr) |> fst
+
+    static member CompileExpressionWithDeps (comp, expr) =
+        DotNetToJavaScript(comp).TransformExpressionWithDeps(expr)
 
     member this.AnotherNode() = DotNetToJavaScript(comp, currentNode :: inProgress)    
 

--- a/src/compiler/WebSharper.Compiler/Translator.fs
+++ b/src/compiler/WebSharper.Compiler/Translator.fs
@@ -726,7 +726,8 @@ type DotNetToJavaScript private (comp: Compilation, ?inProgress) =
     member this.TransformExpressionWithDeps(expr) =
         let node = M.ExtraBundleEntryPointNode ("Expr", System.Guid.NewGuid().ToString())
         currentNode <- node
-        let res = this.TransformExpression(expr)
+        let wrap e = ExprStatement(ItemSet(Global [], Value (String "EntryPoint"), Lambda([], e)))
+        let res = this.TransformExpression(expr) |> wrap |> breakStatement
         res, node
     
     static member CompileExpression (comp, expr) =

--- a/src/compiler/WebSharper.Compiler/Translator.fsi
+++ b/src/compiler/WebSharper.Compiler/Translator.fsi
@@ -29,6 +29,6 @@ type DotNetToJavaScript =
 
     static member CompileFull : comp: Compilation -> unit
 
-    static member CompileExpression : comp: Compilation * expr: Expression -> Expression
+    static member CompileExpression : comp: Compilation * expr: Expression -> Statement
 
-    static member CompileExpressionWithDeps : comp: Compilation * expr: Expression -> Expression * Metadata.Node
+    static member CompileExpressionWithDeps : comp: Compilation * expr: Expression -> Statement * Metadata.Node

--- a/src/compiler/WebSharper.Compiler/Translator.fsi
+++ b/src/compiler/WebSharper.Compiler/Translator.fsi
@@ -30,3 +30,5 @@ type DotNetToJavaScript =
     static member CompileFull : comp: Compilation -> unit
 
     static member CompileExpression : comp: Compilation * expr: Expression -> Expression
+
+    static member CompileExpressionWithDeps : comp: Compilation * expr: Expression -> Expression * Metadata.Node

--- a/src/compiler/WebSharper.Compiler/Translator.fsi
+++ b/src/compiler/WebSharper.Compiler/Translator.fsi
@@ -29,6 +29,4 @@ type DotNetToJavaScript =
 
     static member CompileFull : comp: Compilation -> unit
 
-    static member CompileExpression : comp: Compilation * expr: Expression -> Statement
-
-    static member CompileExpressionWithDeps : comp: Compilation * expr: Expression -> Statement * Metadata.Node
+    static member CompileExpression : comp: Compilation * expr: Expression * ?node: Metadata.Node -> Expression

--- a/src/compiler/WebSharper.Compiler/WebSharper.Compiler.fsproj
+++ b/src/compiler/WebSharper.Compiler/WebSharper.Compiler.fsproj
@@ -21,9 +21,9 @@
     <Compile Include="Recognize.fs" />
     <Compile Include="Verifier.fs" />
     <Compile Include="CompilationTypes.fs" />
-    <Compile Include="Compilation.fs" />
     <Compile Include="QuotationReader.fs" />
     <Compile Include="ReflectedDefinitionReader.fs" />
+    <Compile Include="Compilation.fs" />
     <Compile Include="Translator.fsi" />
     <Compile Include="Translator.fs" />
     <Compile Include="Stubs.fs" />
@@ -43,6 +43,7 @@
     <Compile Include="api/Loader.fs" />
     <Compile Include="Reflector.fsi" />
     <Compile Include="Reflector.fs" />
+    <Compile Include="QuotationCompiler.fs" />
     <Compile Include="FrontEnd.fs" />
     <Compile Include="WIGCompile.fsi" />
     <Compile Include="WIGCompile.fs" />

--- a/src/compiler/WebSharper.Core/Graph.fs
+++ b/src/compiler/WebSharper.Core/Graph.fs
@@ -410,16 +410,3 @@ type Graph =
             Lookup = Dictionary()
             Resources = ConcurrentDictionary()
         }
-
-namespace WebSharper.Core
-
-module MetatadaExtension =
-
-    open WebSharper.Core.Metadata
-    open WebSharper.Core.DependencyGraph
-
-    type Info with
-        static member Union (metas: seq<Info>) = 
-            { WebSharper.Core.Metadata.Info.UnionWithoutDependencies metas with
-                Dependencies = Graph.NewWithDependencyAssemblies(metas |> Seq.map (fun m -> m.Dependencies)).GetData()
-            }

--- a/src/compiler/WebSharper.Core/Graph.fs
+++ b/src/compiler/WebSharper.Core/Graph.fs
@@ -411,3 +411,15 @@ type Graph =
             Resources = ConcurrentDictionary()
         }
 
+namespace WebSharper.Core
+
+module MetatadaExtension =
+
+    open WebSharper.Core.Metadata
+    open WebSharper.Core.DependencyGraph
+
+    type Info with
+        static member Union (metas: seq<Info>) = 
+            { WebSharper.Core.Metadata.Info.UnionWithoutDependencies metas with
+                Dependencies = Graph.NewWithDependencyAssemblies(metas |> Seq.map (fun m -> m.Dependencies)).GetData()
+            }

--- a/src/compiler/WebSharper.Core/Metadata.fs
+++ b/src/compiler/WebSharper.Core/Metadata.fs
@@ -375,7 +375,7 @@ type Info =
             ResourceHashes = Dict.union (metas |> Seq.map (fun m -> m.ResourceHashes))
             ExtraBundles = Set.unionMany (metas |> Seq.map (fun m -> m.ExtraBundles))
         }
-
+    
     member this.DiscardExpressions() =
         { this with
             Classes =

--- a/tests/WebSharper.Tests/QuotationTests.fsx
+++ b/tests/WebSharper.Tests/QuotationTests.fsx
@@ -18,9 +18,9 @@
 //
 // $end{copyright}
 #I __SOURCE_DIRECTORY__
-#r "../../build/Release/FSharp/net461/Mono.Cecil.dll"
-#r "../../build/Release/FSharp/net461/Mono.Cecil.Mdb.dll"
-#r "../../build/Release/FSharp/net461/Mono.Cecil.Pdb.dll"
+#r "../../build/Release/net461/Mono.Cecil.dll"
+#r "../../build/Release/net461/Mono.Cecil.Mdb.dll"
+#r "../../build/Release/net461/Mono.Cecil.Pdb.dll"
 #r "System.Configuration.dll"
 #r "System.Core.dll"
 #r "System.Data.dll"
@@ -38,7 +38,7 @@
 #r "../../build/Release/net461/WebSharper.Control.dll"
 #r "../../build/Release/net461/WebSharper.Web.dll"
 #r "../../build/Release/net461/WebSharper.Sitelets.dll"
-#r "../../build/Release/FSharp/net461/WebSharper.Compiler.dll"
+#r "../../build/Release/net461/WebSharper.Compiler.dll"
 
 fsi.ShowDeclarationValues <- false
 
@@ -80,8 +80,8 @@ open WebSharper.Core.JavaScript
 
 let translate expr = 
     let compiler = QuotationCompiler(metadata)
-    let ast, js = compiler.Compile(expr)
-    Writer.ExpressionToString Preferences.Readable js
+    let js, refs = compiler.CompileToJSAndRefs(expr, WebSharper.Core.JavaScript.Preferences.Readable)
+    js
 
 translate <@ [ 1; 2 ] |> List.map (fun x -> x + 1) @>
 

--- a/tests/WebSharper.Tests/QuotationTests.fsx
+++ b/tests/WebSharper.Tests/QuotationTests.fsx
@@ -70,7 +70,7 @@ let metadata =
         )
     { 
         WebSharper.Core.Metadata.Info.UnionWithoutDependencies metas with
-            Dependencies = WebSharper.Core.DependencyGraph.Graph.NewWithDependencyAssemblies(metas |> Seq.map (fun m -> m.Dependencies)).GetData()
+            Dependencies = WebSharper.Core.DependencyGraph.Graph.FromData(metas |> Seq.map (fun m -> m.Dependencies)).GetData()
     }
 
 open System.IO
@@ -81,7 +81,7 @@ open WebSharper.Core.JavaScript
 let translate expr = 
     let compiler = QuotationCompiler(metadata)
     let js, refs = compiler.CompileToJSAndRefs(expr, WebSharper.Core.JavaScript.Preferences.Readable)
-    js
+    js, refs |> List.length
 
 translate <@ [ 1; 2 ] |> List.map (fun x -> x + 1) @>
 

--- a/tests/WebSharper.Tests/QuotationTests.fsx
+++ b/tests/WebSharper.Tests/QuotationTests.fsx
@@ -1,0 +1,131 @@
+// $begin{copyright}
+//
+// This file is part of WebSharper
+//
+// Copyright (c) 2008-2018 IntelliFactory
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// $end{copyright}
+#I __SOURCE_DIRECTORY__
+#r "../../build/Release/FSharp/net461/Mono.Cecil.dll"
+#r "../../build/Release/FSharp/net461/Mono.Cecil.Mdb.dll"
+#r "../../build/Release/FSharp/net461/Mono.Cecil.Pdb.dll"
+#r "System.Configuration.dll"
+#r "System.Core.dll"
+#r "System.Data.dll"
+#r "System.dll"
+#r "System.Numerics.dll"
+#r "System.Web.dll"
+#r "System.Xml.dll"
+#r "System.Xml.Linq.dll"
+#r "../../build/Release/net461/WebSharper.Core.JavaScript.dll"
+#r "../../build/Release/net461/WebSharper.Core.dll"
+#r "../../build/Release/net461/WebSharper.JavaScript.dll"
+#r "../../build/Release/net461/WebSharper.JQuery.dll"
+#r "../../build/Release/net461/WebSharper.Main.dll"
+#r "../../build/Release/net461/WebSharper.Collections.dll"
+#r "../../build/Release/net461/WebSharper.Control.dll"
+#r "../../build/Release/net461/WebSharper.Web.dll"
+#r "../../build/Release/net461/WebSharper.Sitelets.dll"
+#r "../../build/Release/FSharp/net461/WebSharper.Compiler.dll"
+
+fsi.ShowDeclarationValues <- false
+
+open System
+open System.IO
+open System.Collections.Generic
+
+let wsRefs =
+    let wsLib x = 
+        Path.Combine(__SOURCE_DIRECTORY__, @"..\..\build\Release\net461", x + ".dll")
+    List.map wsLib [
+        "WebSharper.Core.JavaScript"
+        "WebSharper.Core"
+        "WebSharper.JavaScript"
+        "WebSharper.JQuery"
+        "WebSharper.Main"
+        "WebSharper.Collections"
+        "WebSharper.Control"
+        "WebSharper.Web"
+        "WebSharper.Sitelets"
+        //"WebSharper.Tests"
+        //"WebSharper.InterfaceGenerator.Tests"
+    ]
+
+let metadata =
+    let metas =
+        wsRefs |> Seq.choose(
+            WebSharper.Compiler.FrontEnd.ReadFromFile WebSharper.Compiler.FrontEnd.ReadOptions.FullMetadata
+        )
+    { 
+        WebSharper.Core.Metadata.Info.UnionWithoutDependencies metas with
+            Dependencies = WebSharper.Core.DependencyGraph.Graph.NewWithDependencyAssemblies(metas |> Seq.map (fun m -> m.Dependencies)).GetData()
+    }
+
+open System.IO
+
+open WebSharper.Compiler
+open WebSharper.Core.JavaScript
+
+let translate expr = 
+    let compiler = QuotationCompiler(metadata)
+    let ast, js = compiler.Compile(expr)
+    Writer.ExpressionToString Preferences.Readable js
+
+translate <@ [ 1; 2 ] |> List.map (fun x -> x + 1) @>
+
+//translate """
+//module M
+
+//open WebSharper
+
+//[<JavaScript>]
+//module Module =
+//    let AnonRecord (x: {| A : int |}) = {| B = x.A |}
+
+//    type AnonRecordInUnion =
+//        | AnonRecordTest of {| A: int; B: string|}
+
+//    let AnonRecordInUnion() =
+//        AnonRecordTest {| A = 3; B = "hi"|}   
+
+//    let AnonRecordNested() =
+//        {| A = 1; B = {| A = 2; B = "hi"|}|}  
+        
+//    let StructAnonRecord() =
+//        let a = struct {| SA = 5 |}
+//        a.SA
+//"""
+
+//translate """
+//module M
+
+//open WebSharper
+
+//module Bug923 =
+//    type V2<[<Measure>] 'u> =
+//        struct
+//            val x : float<'u>
+//            val y : float<'u>
+//            new (x, y) = {x=x; y=y}
+//        end
+
+//        static member (+) (a : V2<_>, b : V2<_>) = 
+//            V2 (a.x + b.x, a.y + b.y)
+
+//    [<JavaScript>]
+//    let addFloatsWithMeasures (a: float<'a>) (b: float<'a>) = a + b
+
+//    """
+

--- a/tests/WebSharper.Tests/WebSharper.Tests.fsproj
+++ b/tests/WebSharper.Tests/WebSharper.Tests.fsproj
@@ -58,6 +58,7 @@
     <Compile Include="Promise.fs" />
     <Compile Include="Compiler.fs" />
     <Compile Include="Main.fs" />
+    <None Include="QuotationTests.fsx" />
     <None Include="ASTTests.fsx" />
     <None Include="paket.references" />
     <Content Include="wsconfig.json" />

--- a/tests/WebSharper.Tests/WebSharper.Tests.fsproj
+++ b/tests/WebSharper.Tests/WebSharper.Tests.fsproj
@@ -61,7 +61,7 @@
     <None Include="QuotationTests.fsx" />
     <None Include="ASTTests.fsx" />
     <None Include="paket.references" />
-    <Content Include="wsconfig.json" />
+    <Content Include="testwsconfig.json" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <ProjectReference Include="..\..\src\compiler\WebSharper.Compiler\WebSharper.Compiler.fsproj" />


### PR DESCRIPTION
For #1095, add class to prepare a compilation from a dynamic assembly based on F# ReflectedDefinitions and to compile quotations.

This is currently a lower-level API that requires some setup, full set of helpers will happen with the revival of WebSharper.Warp project