### PR TITLE
Fix MsBuild trying to chmod the wrong files on *nix

### DIFF
--- a/msbuild/WebSharper.FSharp.targets
+++ b/msbuild/WebSharper.FSharp.targets
@@ -1,10 +1,10 @@
-﻿<!--
+<!--
 // $begin{copyright}
-// 
+//
 // This file is part of WebSharper
-// 
+//
 // Copyright (c) 2008-2014 IntelliFactory
-// 
+//
 // GNU Affero General Public License Usage
 // WebSharper is free software: you can redistribute it and/or modify it under
 // the terms of the GNU Affero General Public License, version 3, as published
@@ -50,21 +50,14 @@
       <CustomAdditionalCompileInputs Include="$(WebSharperConfigFile)" />
     </ItemGroup>
   </Target>
-  <Choose>
-    <When Condition="'$(_WebSharperUseNetFxCompiler)' == 'True'">
-      <PropertyGroup Condition=" '$(WebSharperRunCompiler)' == 'True' ">
-        <FscToolPath>$(MSBuildThisFileDirectory)/../tools/net461</FscToolPath>
-        <FscToolExe>wsfsc.exe</FscToolExe>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup Condition=" '$(WebSharperRunCompiler)' == 'True' ">
-        <FscToolPath>$(MSBuildThisFileDirectory)/../tools/netcoreapp3.1</FscToolPath>
-        <FscToolExe Condition="'$(OS)' == 'Windows_NT'">wsfsc.exe</FscToolExe>
-        <FscToolExe Condition="'$(OS)' != 'Windows_NT'">wsfsc.sh</FscToolExe>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
+
+  <PropertyGroup Condition=" '$(WebSharperRunCompiler)' == 'True' ">
+    <FscToolExe Condition="'$(OS)' == 'Windows_NT'">wsfsc.exe</FscToolExe>
+    <FscToolExe Condition="'$(OS)' == 'Unix'"      >wsfsc.sh</FscToolExe>
+    <FscToolPath Condition="'$(_WebSharperUseNetFxCompiler)' == 'True'">$(MSBuildThisFileDirectory)/../tools/net461</FscToolPath>
+    <FscToolPath Condition="'$(_WebSharperUseNetFxCompiler)' != 'True'">$(MSBuildThisFileDirectory)/../tools/netcoreapp3.1</FscToolPath>
+  </PropertyGroup>
+
   <Target Name="MakeWsfscExecutable" BeforeTargets="CoreCompile" Condition=" '$(WebSharperRunCompiler)' == 'True' AND '$(OS)' != 'Windows_NT'">
     <Exec Command="chmod u+x '$(FscToolPath)/$(FscToolExe)'" />
   </Target>


### PR DESCRIPTION
Building failed on *nix because MsBuild tried to chmod `wsfsc.exe` instead of `wsfsc.sh`
The error is:

```
(...)/core/msbuild/WebSharper.FSharp.targets(69,5): error MSB3073: The command "chmod u+x '
(...)/core/msbuild/../build/Debug/FSharp/netcoreapp3.1/deploy//wsfsc.exe'" exited with code 1.
```