### PR TITLE
Added Floor/Ceiling and compariosn operators to Decimal.fs and tests #1109

### DIFF
--- a/src/compiler/WebSharper.Core/Macros.fs
+++ b/src/compiler/WebSharper.Core/Macros.fs
@@ -530,6 +530,58 @@ type Abs() =
                 MacroError (sprintf "Abs macro error, type not supported: %O" t)
 
 [<Sealed>]
+type Ceiling() =
+    inherit Macro()
+    override this.TranslateCall(c) =
+        let m = c.Method
+        let x = c.Arguments.Head
+        let t = m.Generics.Head
+        if t.IsParameter then
+            MacroNeedsResolvedTypeArg t
+        else
+            match t with
+            | ConcreteType ct ->
+                if scalarTypes.Contains ct.Entity.Value.FullName then
+                    MacroFallback
+                else
+                    let ceilMeth =
+                        Method {
+                            MethodName = "Ceiling"
+                            Parameters = [t]
+                            ReturnType = t
+                            Generics = 0      
+                        }
+                    Call(None, ct, NonGeneric ceilMeth, [x]) |> MacroOk
+            | _ ->
+                MacroError (sprintf "Ceiling macro error, type not supported: %O" t)
+
+[<Sealed>]
+type Floor() =
+    inherit Macro()
+    override this.TranslateCall(c) =
+        let m = c.Method
+        let x = c.Arguments.Head
+        let t = m.Generics.Head
+        if t.IsParameter then
+            MacroNeedsResolvedTypeArg t
+        else
+            match t with
+            | ConcreteType ct ->
+                if scalarTypes.Contains ct.Entity.Value.FullName then
+                    MacroFallback
+                else
+                    let floorMeth =
+                        Method {
+                            MethodName = "Floor"
+                            Parameters = [t]
+                            ReturnType = t
+                            Generics = 0      
+                        }
+                    Call(None, ct, NonGeneric floorMeth, [x]) |> MacroOk
+            | _ ->
+                MacroError (sprintf "Floor macro error, type not supported: %O" t)
+
+[<Sealed>]
 type Sign() =
     inherit Macro()
     override this.TranslateCall(c) =

--- a/src/compiler/WebSharper.Core/Macros.fsi
+++ b/src/compiler/WebSharper.Core/Macros.fsi
@@ -54,6 +54,16 @@ type Abs =
     inherit Macro
 
 [<Sealed>]
+type Ceiling =
+    new : unit -> Ceiling
+    inherit Macro
+
+[<Sealed>]
+type Floor =
+    new : unit -> Floor
+    inherit Macro
+
+[<Sealed>]
 type Sign =
     new : unit -> Sign
     inherit Macro

--- a/src/stdlib/WebSharper.Main.Proxies/Operators.fs
+++ b/src/stdlib/WebSharper.Main.Proxies/Operators.fs
@@ -170,6 +170,7 @@ let Atan2 (x: 'T1) (y: 'T1) = X<'T2>
 [<Inline "$x">]
 let Box (x: 'T) = X<obj>
 
+[<Macro(typeof<M.Ceiling>)>]
 [<Inline "Math.ceil($x)">]
 let Ceiling (x: 'T) = X<'T>
 
@@ -223,6 +224,7 @@ let FailWith (msg: string) : 'T = raise (exn msg)
 [<Macro(typeof<M.Conversion>)>]
 let ToFloat (x: 'T) = X<float>
 
+[<Macro(typeof<M.Floor>)>]
 [<Inline "Math.floor($x)">]
 let Floor (x: 'T) = X<'T>
 
@@ -364,6 +366,7 @@ let inline Tan (x: 'T) = X<'T>
 [<Inline "(Math.exp(2*$x)-1)/(Math.exp(2*$x)+1)">]
 let Tanh (x: 'T) = X<'T>
 
+[<Inline>]
 let inline Truncate<'T> (x: 'T) =
     if x <. 0 then Ceiling x else Floor x
 

--- a/src/stdlib/WebSharper.MathJS.Extensions/Decimal.fs
+++ b/src/stdlib/WebSharper.MathJS.Extensions/Decimal.fs
@@ -120,6 +120,9 @@ type internal DecimalProxy =
     static member Add(n1 : decimal, n2 : decimal) : decimal = DecimalProxy.mul WSDecimalMath.Add n1 n2
 
     [<Inline>]
+    static member Ceiling(d: decimal) : decimal = DecimalProxy.un WSDecimalMath.Ceil d
+
+    [<Inline>]
     static member Compare(n1 : decimal, n2 : decimal) : int = DecimalProxy.bin WSDecimalMath.Compare n1 n2 |> float |> As<int>
 
     [<Inline>]
@@ -136,6 +139,9 @@ type internal DecimalProxy =
 
     [<Inline>]
     static member Equals(a: decimal, b : decimal): bool = DecimalProxy.bin WSDecimalMath.Equal a b |> As<bool>
+
+    [<Inline>]
+    static member Floor(d: decimal) : decimal = DecimalProxy.un WSDecimalMath.Floor d
 
     [<Inline>]
     static member internal Max(n1 : decimal, n2 : decimal): decimal =
@@ -213,3 +219,9 @@ type private MathProxyForDecimals =
 
     [<Inline>]
     static member Min(n1 : decimal, n2 : decimal): decimal = DecimalProxy.Min(n1, n2)
+
+    [<Inline>]
+    static member Ceiling(d: decimal) = DecimalProxy.Ceiling d
+
+    [<Inline>]
+    static member Floor(d: decimal) = DecimalProxy.Floor d

--- a/src/stdlib/WebSharper.MathJS.Extensions/Decimal.fs
+++ b/src/stdlib/WebSharper.MathJS.Extensions/Decimal.fs
@@ -141,6 +141,12 @@ type internal DecimalProxy =
     static member Equals(a: decimal, b : decimal): bool = DecimalProxy.bin WSDecimalMath.Equal a b |> As<bool>
 
     [<Inline>]
+    static member GreaterThan(a: decimal, b: decimal): bool = DecimalProxy.bin WSDecimalMath.Larger a b |> As<bool>
+
+    [<Inline>]
+    static member LessThan(a: decimal, b: decimal): bool = DecimalProxy.bin WSDecimalMath.Smaller a b |> As<bool>
+
+    [<Inline>]
     static member Floor(d: decimal) : decimal = DecimalProxy.un WSDecimalMath.Floor d
 
     [<Inline>]
@@ -183,6 +189,18 @@ type internal DecimalProxy =
 
     [<Inline>]
     static member op_Inequality(n1 : decimal, n2 : decimal): bool = not <| DecimalProxy.Equals (n1,n2)
+
+    [<Inline>]
+    static member op_GreaterThan(n1:decimal, n2:decimal): bool = DecimalProxy.GreaterThan (n1, n2)
+
+    [<Inline>]
+    static member op_LessThan(n1:decimal, n2:decimal): bool = DecimalProxy.LessThan (n1, n2)
+
+    [<Inline>]
+    static member op_GreaterThanOrEqual(n1:decimal, n2:decimal): bool = not <| DecimalProxy.LessThan (n1, n2)
+
+    [<Inline>]
+    static member op_LessThanOrEqual(n1:decimal, n2:decimal): bool = not <| DecimalProxy.GreaterThan (n1, n2)
 
     [<Inline>]
     static member op_Modulus(n1 : decimal, n2 : decimal): decimal = DecimalProxy.bin WSDecimalMath.Mod n1 n2

--- a/tests/WebSharper.Tests/MathJS.fs
+++ b/tests/WebSharper.Tests/MathJS.fs
@@ -273,15 +273,19 @@ let Tests runServerSide =
         }
 
         Test "Decimal functions" {
-            equal (abs 5m) 5m
+            let x = 18133887298.441562272235520m
+            equal (abs x) x
             equal (abs -6m) 6m
             equal (System.Math.Abs -7m) 7m
             equal (sign 3m) 1
             equal (sign -3m) -1
-            let x = 18133887298.441562272235520m
             let y = x + 1m
             equal (max x y) y
             equal (min x y) x
+            equal (System.Math.Ceiling x) 18133887299m
+            equal (System.Math.Floor x) 18133887298m
+            equal (ceil x) 18133887299m
+            equal (floor x) 18133887298m
         }
 
         TestIf runServerSide "Decimal remoting" {

--- a/tests/WebSharper.Tests/MathJS.fs
+++ b/tests/WebSharper.Tests/MathJS.fs
@@ -288,6 +288,17 @@ let Tests runServerSide =
             equal (floor x) 18133887298m
         }
 
+        Test "Decimal comparison" {
+            let x = 18133887298.441562272235520m
+            let y = 18133887298.441562272237357m
+            isTrue (x < y)
+            isFalse (x > y)
+            isTrue (x <= y)
+            isTrue (x <= x)
+            isFalse (x >= y)
+            isTrue (y >= y)
+        }
+
         TestIf runServerSide "Decimal remoting" {
             let x = 18133887298.441562272235520m
             let! res = Add1ToDecimal x 


### PR DESCRIPTION
Solution for https://github.com/dotnet-websharper/core/issues/1109
Implemented in decimal:

- Floor
- Ceiling
- <, >, <=, >=