### PR TITLE
Fixed test for nullable `Implicit interop with nullable value types`, added template test to `Default interface member consumption` #1112

### DIFF
--- a/src/compiler/WebSharper.FSharp.Service/Program.fs
+++ b/src/compiler/WebSharper.FSharp.Service/Program.fs
@@ -201,6 +201,9 @@ let startListening() =
     Console.ReadLine() |> ignore
     tokenSource.Cancel()
 
+[<assembly: System.Reflection.AssemblyTitleAttribute("WebSharper Booster " + AssemblyVersionInformation.AssemblyFileVersion)>]
+[<assembly: System.Reflection.AssemblyDescriptionAttribute("WebSharper Booster " + AssemblyVersionInformation.AssemblyFileVersion)>]
+do ()
 
 [<EntryPoint>]
 let main _ =

--- a/tests/WebSharper.CSharp.Tests/Object.cs
+++ b/tests/WebSharper.CSharp.Tests/Object.cs
@@ -379,4 +379,9 @@ namespace WebSharper.CSharp.Tests
             return PartialMethodRelaxed();
         }
     }
+
+    [JavaScript]
+    public interface IFoo {
+        public int Bar => 0;
+    }
 }

--- a/tests/WebSharper.Tests/Nullable.fs
+++ b/tests/WebSharper.Tests/Nullable.fs
@@ -74,5 +74,6 @@ let Tests =
         Test "Auto-conversion" {
             equal (WebSharper.CSharp.Tests.Interop.AddNullables(2, 3)) 5
             equal (WebSharper.CSharp.Tests.Interop.AddNullables(2, Nullable())) 2
+            equal (WebSharper.CSharp.Tests.Interop.AddNullables(2, 3)) (WebSharper.CSharp.Tests.Interop.AddNullables(Nullable<int>2, Nullable<int>3))
         }
     }

--- a/tests/WebSharper.Tests/Object.fs
+++ b/tests/WebSharper.Tests/Object.fs
@@ -201,6 +201,12 @@ type AlwaysEqual (x) =
 type IA<'T> =
     abstract member Get : unit -> 'T
 
+[<JavaScript>]
+type MyType() =
+    member __.M() = ()
+
+    interface WebSharper.CSharp.Tests.IFoo
+
 //[<JavaScript>]
 //type MultipleIntf() =
 //    interface IA<int> with
@@ -497,12 +503,22 @@ let Tests =
             equal y.SR2b "a"
         }
 
-        //Test "Interfaces with multiple generic implementations" {
+        Skip "Default interface member consumption" {
+            // let a = MyType() :> WebSharper.CSharp.Tests.IFoo
+            // let b = { new WebSharper.CSharp.Tests.IFoo }
+
+            // equal a.Bar 0
+            // equal b.Bar 0
+            equal 1 1
+        }
+
+        Skip "Interfaces with multiple generic implementations" {
         //    let mc = MultipleIntf()
         //    let iaInt = mc :> IA<int>
         //    let iaString = mc :> IA<string>
         //    equal (iaInt.Get()) 1
         //    equal (iaString.Get()) "hello"
-        //}
+            equal 1 1
+        }
 
     }


### PR DESCRIPTION
Fix to: https://github.com/dotnet-websharper/core/issues/1112