### PR TITLE
Get services from http context

### DIFF
--- a/src/sitelets/WebSharper.AspNetCore/Context.fs
+++ b/src/sitelets/WebSharper.AspNetCore/Context.fs
@@ -180,7 +180,7 @@ type private UserSession(httpCtx: HttpContext, options: WebSharperOptions) =
 let private makeEnv (httpCtx: HttpContext) (options: WebSharperOptions) =
     dict [|
         "WebSharper.AspNetCore.HttpContext", box httpCtx
-        "WebSharper.AspNetCore.Services", box options.Services
+        "WebSharper.AspNetCore.Services", box httpCtx.Services
     |]
 
 let Make (httpCtx: HttpContext) (options: WebSharperOptions) =


### PR DESCRIPTION
From a [discussion on Gitter](https://gitter.im/intellifactory/websharper?at=610e3ad6025d436054b8f8ca) it appears that the services made available through 
"WebSharper.AspNetCore.Services" don't include the scoped services because they are taken from the WebSharperOptions instance.
This change fixes the code and services are now taken from the HttpContext, implementing the workaround indicated by @Tarmil  .