### PR TITLE
Implement #1200 graceful shutdown message for wsfscservice

### DIFF
--- a/src/compiler/WebSharper.Compiler/AssemblyResolution.fs
+++ b/src/compiler/WebSharper.Compiler/AssemblyResolution.fs
@@ -64,13 +64,10 @@ module Implemetnation =
     let amsToDictByName paths =
         paths
         |> Seq.choose (fun path ->
-            let asmName = 
-                try
-                    Some (AssemblyName.GetAssemblyName path)
-                with _ -> None
-            match asmName with
-            | None -> None
-            | Some n -> Some (n.Name, path)
+            try
+                let assemblyName = AssemblyName.GetAssemblyName path
+                Some (assemblyName.Name, path)
+            with _ -> None
         )
         |> dict
 

--- a/src/compiler/WebSharper.FSharp.Service/Program.fs
+++ b/src/compiler/WebSharper.FSharp.Service/Program.fs
@@ -68,95 +68,105 @@ let startListening() =
             // nLogger.Trace "Reading assembly: %s" x makes this compilation fail. No Tracing here.
             WebSharper.Compiler.FrontEnd.TryReadFromAssembly WebSharper.Core.Metadata.MetadataOptions.FullMetadata r
 
+    // client starts the service without window. You have to shut down the service from Task Manager/ kill command.
+    // or use dotnet-ws tool, and send a [|"exit"|] message.
+    use locker = new AutoResetEvent(false)
     let agent = MailboxProcessor.Start(fun inbox ->
 
         // the message processing function
         // compilations are serialed by a MailboxProcessor
         let rec messageLoop () = async {
 
+            let mutable exited = false
             // a compilation failing because a client disconnects can still process the next compilation
             try
                 // read a message
                 let! (deserializedMessage: ArgsType, serverPipe: NamedPipeServerStream, token) = inbox.Receive()
-                let tryGetDirectoryName (path: string) =
-                    try
-                       System.IO.Path.GetDirectoryName path |> Some
-                    with
-                    | :? System.DivideByZeroException -> None
+                if deserializedMessage = { args = [| "exit" |] } then
+                    exited <- true
+                else
+                    let tryGetDirectoryName (path: string) =
+                        try
+                           System.IO.Path.GetDirectoryName path |> Some
+                        with
+                        | :? System.DivideByZeroException -> None
 
-                let joinTailIfSome (array: string array) =
-                    match array with
-                    | [||] -> None
-                    | x -> System.String.Join(":", x) |> Some
+                    let joinTailIfSome (array: string array) =
+                        match array with
+                        | [||] -> None
+                        | x -> System.String.Join(":", x) |> Some
 
-                // read the project file
-                let projectOption = 
-                    deserializedMessage.args
-                    |> Array.tryFind (fun x -> x.IndexOf("--project", System.StringComparison.OrdinalIgnoreCase) >= 0)
-                    |> Option.bind (fun x -> x.Split(':') |> Array.tail |> joinTailIfSome)
-                let projectDirOption = projectOption |> Option.bind tryGetDirectoryName
-                match projectDirOption with
-                | Some project -> 
-                    System.Environment.CurrentDirectory <- project
-                    nLogger.Debug(sprintf "Compiling %s" projectOption.Value)
-                    let send paramPrint str = async {
-                        let newMessage = paramPrint str
-                        nLogger.Trace(sprintf "Server sends: %s" newMessage)
-                        let bf = new BinaryFormatter()
-                        use ms = new MemoryStream()
-                        bf.Serialize(ms, newMessage)
-                        ms.Flush()
-                        ms.Position <- 0L
-                        do! ms.CopyToAsync(serverPipe) |> Async.AwaitTask
-                        serverPipe.Flush()
-                    }
-                    // all compilation output goes through a logger. This in standalone mode goes to stdout and stderr
-                    // in service compilation it's proxied through a NamedPipeStream. prefixed with n: or e: or x: (error code)
-                    let logger = { new LoggerBase() with
-                            override _.Out s =
-                                let sendOut = sprintf "n: %s" |> send
-                                let asyncValue = 
-                                    s
-                                    |> sendOut
-                                Async.RunSynchronously(asyncValue, cancellationToken = token)
-                            override _.Error s =
-                                let sendErr = sprintf "e: %s" |> send
-                                let asyncValue = 
-                                    s
-                                    |> sendErr
-                                Async.RunSynchronously(asyncValue, cancellationToken = token)
+                    // read the project file
+                    let projectOption = 
+                        deserializedMessage.args
+                        |> Array.tryFind (fun x -> x.IndexOf("--project", System.StringComparison.OrdinalIgnoreCase) >= 0)
+                        |> Option.bind (fun x -> x.Split(':') |> Array.tail |> joinTailIfSome)
+                    let projectDirOption = projectOption |> Option.bind tryGetDirectoryName
+                    match projectDirOption with
+                    | Some project -> 
+                        System.Environment.CurrentDirectory <- project
+                        nLogger.Debug(sprintf "Compiling %s" projectOption.Value)
+                        let send paramPrint str = async {
+                            let newMessage = paramPrint str
+                            nLogger.Trace(sprintf "Server sends: %s" newMessage)
+                            let bf = new BinaryFormatter()
+                            use ms = new MemoryStream()
+                            bf.Serialize(ms, newMessage)
+                            ms.Flush()
+                            ms.Position <- 0L
+                            do! ms.CopyToAsync(serverPipe) |> Async.AwaitTask
+                            serverPipe.Flush()
                         }
-                            
-                    let sendFinished = sprintf "x: %i" |> send
-                    // use the same differentiation like --standalone
+                        // all compilation output goes through a logger. This in standalone mode goes to stdout and stderr
+                        // in service compilation it's proxied through a NamedPipeStream. prefixed with n: or e: or x: (error code)
+                        let logger = { new LoggerBase() with
+                                override _.Out s =
+                                    let sendOut = sprintf "n: %s" |> send
+                                    let asyncValue = 
+                                        s
+                                        |> sendOut
+                                    Async.RunSynchronously(asyncValue, cancellationToken = token)
+                                override _.Error s =
+                                    let sendErr = sprintf "e: %s" |> send
+                                    let asyncValue = 
+                                        s
+                                        |> sendErr
+                                    Async.RunSynchronously(asyncValue, cancellationToken = token)
+                            }
+                                
+                        let sendFinished = sprintf "x: %i" |> send
+                        // use the same differentiation like --standalone
 
-                    let compilationResultForDebugOrRelease() =
-                        let parsedOptions = ParseOptions deserializedMessage.args logger
-                        match parsedOptions with
-                        | HelpOrCommand r ->
-                            r // unexpected, wsfsc.exe should handle this
-                        | ParsedOptions (wsConfig, warnSettings) ->
+                        let compilationResultForDebugOrRelease() =
+                            let parsedOptions = ParseOptions deserializedMessage.args logger
+                            match parsedOptions with
+                            | HelpOrCommand r ->
+                                r // unexpected, wsfsc.exe should handle this
+                            | ParsedOptions (wsConfig, warnSettings) ->
 #if DEBUG
-                            Compile wsConfig warnSettings logger checkerFactory tryGetMetadata
+                                Compile wsConfig warnSettings logger checkerFactory tryGetMetadata
 #else
-                            try Compile wsConfig warnSettings logger checkerFactory tryGetMetadata
-                            with 
-                            | ArgumentError msg -> 
-                                PrintGlobalError logger (msg + " - args: " + (deserializedMessage.args |> String.concat " "))
-                                1
-                            | e -> 
-                                PrintGlobalError logger (sprintf "Global error: %A" e)
-                                1
+                                try Compile wsConfig warnSettings logger checkerFactory tryGetMetadata
+                                with 
+                                | ArgumentError msg -> 
+                                    PrintGlobalError logger (msg + " - args: " + (deserializedMessage.args |> String.concat " "))
+                                    1
+                                | e -> 
+                                    PrintGlobalError logger (sprintf "Global error: %A" e)
+                                    1
 #endif
-                    let returnValue = compilationResultForDebugOrRelease()
-                    do! sendFinished returnValue
-                | None ->
-                    ()
+                        let returnValue = compilationResultForDebugOrRelease()
+                        do! sendFinished returnValue
+                    | None ->
+                        ()
             with 
             | ex -> 
                 nLogger.Error(ex, "Error in MailBoxProcessor loop")
-            // loop to top
-            return! messageLoop ()
+            if exited then
+                locker.Set() |> ignore
+            else 
+                // loop to top
+                return! messageLoop ()
             }
 
         // start the loop
@@ -204,8 +214,6 @@ let startListening() =
     let tokenSource = new CancellationTokenSource()
     nLogger.Debug(sprintf "Server listening started on %s pipeName" pipeName)
     Async.Start (pipeListener tokenSource.Token)
-    // client starts the service without window. You have to shut down the service from Task Manager/ kill command.
-    use locker = new AutoResetEvent(false)
     locker.WaitOne() |> ignore
 
     tokenSource.Cancel()

--- a/src/compiler/WebSharper.FSharp.Service/Program.fs
+++ b/src/compiler/WebSharper.FSharp.Service/Program.fs
@@ -77,13 +77,13 @@ let startListening() =
         // compilations are serialed by a MailboxProcessor
         let rec messageLoop () = async {
 
-            let mutable exited = false
+            let mutable exiting = false
             // a compilation failing because a client disconnects can still process the next compilation
             try
                 // read a message
                 let! (deserializedMessage: ArgsType, serverPipe: NamedPipeServerStream, token) = inbox.Receive()
                 if deserializedMessage = { args = [| "exit" |] } then
-                    exited <- true
+                    exiting <- true
                 else
                     let tryGetDirectoryName (path: string) =
                         try
@@ -162,7 +162,7 @@ let startListening() =
             with 
             | ex -> 
                 nLogger.Error(ex, "Error in MailBoxProcessor loop")
-            if exited then
+            if exiting && inbox.CurrentQueueLength <> 0 then
                 locker.Set() |> ignore
             else 
                 // loop to top

--- a/src/compiler/WebSharper.FSharp/wsfscservice_start.cmd
+++ b/src/compiler/WebSharper.FSharp/wsfscservice_start.cmd
@@ -1,4 +1,4 @@
-﻿@echo off
+@echo off
 
 start /d %~dp0 /b wsfscservice.exe
 :: dotnet "%~dp0WsFscService.dll"


### PR DESCRIPTION
wsfscservice's MailBoxProcessor starts a shutdown sequence for a [|"exit"|] args message. The `AutoResetEvent` that retained the service from stopping now triggered to exit, when the [|"exit"|] message is processed after the already enqueued compilations.