### PR TITLE
Sitelets create root.js when non-prebundled

### DIFF
--- a/src/compiler/WebSharper.Compiler.CSharp/Compile.fs
+++ b/src/compiler/WebSharper.Compiler.CSharp/Compile.fs
@@ -133,8 +133,18 @@ let Compile config (logger: LoggerBase) tryGetMetadata =
                 | Some (Bundle | Website | Service) -> Some (config.RuntimeMetadata, metas)
                 | _ -> None
 
+            let isSitelet =
+                match config.ProjectType with
+                | Some Html ->
+                    true
+                | Some Website
+                | _ when Option.isSome config.OutputDir ->
+                    true
+                | _ -> 
+                    false
+
             let js, currentMeta, sources, res =
-                ModifyAssembly logger (Some comp) refMeta currentMeta config.SourceMap config.TypeScriptDeclaration config.TypeScriptOutput config.AnalyzeClosures runtimeMeta assem (config.ProjectType = None) config.PreBundle
+                ModifyAssembly logger (Some comp) refMeta currentMeta config.SourceMap config.TypeScriptDeclaration config.TypeScriptOutput config.AnalyzeClosures runtimeMeta assem (config.ProjectType = None) config.PreBundle isSitelet
 
             match config.ProjectType with
             | Some (Bundle | Website) ->

--- a/src/compiler/WebSharper.Compiler.FSharp/Compile.fs
+++ b/src/compiler/WebSharper.Compiler.FSharp/Compile.fs
@@ -248,9 +248,18 @@ let Compile (config : WsConfig) (warnSettings: WarnSettings) (logger: LoggerBase
 
                 let isLibrary = config.ProjectType = None 
 
-                let js, currentMeta, sources, res =
-                    ModifyAssembly logger (Some comp) (getRefMeta()) currentMeta config.SourceMap config.TypeScriptDeclaration config.TypeScriptOutput config.AnalyzeClosures runtimeMeta assem isLibrary config.PreBundle
+                let isSitelet =
+                    match config.ProjectType with
+                    | Some Html ->
+                        true
+                    | Some Website
+                    | _ when Option.isSome config.OutputDir ->
+                        true
+                    | _ -> 
+                        false
 
+                let js, currentMeta, sources, res =
+                    ModifyAssembly logger (Some comp) (getRefMeta()) currentMeta config.SourceMap config.TypeScriptDeclaration config.TypeScriptOutput config.AnalyzeClosures runtimeMeta assem isLibrary config.PreBundle isSitelet
                 match config.ProjectType with
                 | Some (Bundle | Website) ->
                     let wsRefs =

--- a/src/compiler/WebSharper.Compiler/FrontEnd.fs
+++ b/src/compiler/WebSharper.Compiler/FrontEnd.fs
@@ -115,7 +115,7 @@ let CreateBundleJSOutput (logger: LoggerBase) refMeta current entryPoint =
 
     Some ("", "")
 
-let CreateResources (logger: LoggerBase) (comp: Compilation option) (refMeta: M.Info) (current: M.Info) sourceMap dts ts closures (runtimeMeta: option<M.MetadataOptions * M.Info list>) (a: Mono.Cecil.AssemblyDefinition) isLibrary prebundle =
+let CreateResources (logger: LoggerBase) (comp: Compilation option) (refMeta: M.Info) (current: M.Info) sourceMap dts ts closures (runtimeMeta: option<M.MetadataOptions * M.Info list>) (a: Mono.Cecil.AssemblyDefinition) isLibrary prebundle isSitelet =
     let assemblyName = a.Name.Name
     let sourceMap = false // TODO what about source mapping with all the small files
     let currentPosFixed, sources =
@@ -214,6 +214,14 @@ let CreateResources (logger: LoggerBase) (comp: Compilation option) (refMeta: M.
                         bname, js, trAddrMap
                     )
                     |> Array.ofSeq |> Some
+                elif isSitelet then
+                    let rootJS, addrMap = JavaScriptPackager.packageEntryPointReexport meta
+                    let program, _, trAddrMap = rootJS |> WebSharper.Compiler.JavaScriptWriter.transformProgramAndAddrMap O.JavaScript WebSharper.Core.JavaScript.Readable addrMap
+                    let js, _, _ = WebSharper.Compiler.JavaScriptPackager.programToString WebSharper.Core.JavaScript.Readable WebSharper.Core.JavaScript.Writer.CodeWriter program false
+                    logger.TimedStage (sprintf "Writing reexports all.js")
+                    Some [|
+                        "all", js, trAddrMap    
+                    |]
                 else
                     None
             let updated =
@@ -382,16 +390,16 @@ let CreateResources (logger: LoggerBase) (comp: Compilation option) (refMeta: M.
         addMeta()
         None, currentPosFixed, sources, res.ToArray()
 
-let ModifyCecilAssembly (logger: LoggerBase) (comp: Compilation option) (refMeta: M.Info) (current: M.Info) sourceMap dts ts closures runtimeMeta (a: Mono.Cecil.AssemblyDefinition) isLibrary prebundle =
-    let jsOpt, currentPosFixed, sources, res = CreateResources logger comp refMeta current sourceMap dts ts closures runtimeMeta a isLibrary prebundle
+let ModifyCecilAssembly (logger: LoggerBase) (comp: Compilation option) (refMeta: M.Info) (current: M.Info) sourceMap dts ts closures runtimeMeta (a: Mono.Cecil.AssemblyDefinition) isLibrary prebundle isSitelet =
+    let jsOpt, currentPosFixed, sources, res = CreateResources logger comp refMeta current sourceMap dts ts closures runtimeMeta a isLibrary prebundle isSitelet
     let pub = Mono.Cecil.ManifestResourceAttributes.Public
     for name, contents in res do
         Mono.Cecil.EmbeddedResource(name, pub, contents)
         |> a.MainModule.Resources.Add
     jsOpt, currentPosFixed, sources, res
 
-let ModifyAssembly (logger: LoggerBase) (comp: Compilation option) (refMeta: M.Info) (current: M.Info) sourceMap dts ts closures runtimeMeta (assembly : Assembly) isLibrary =
-    ModifyCecilAssembly logger comp refMeta current sourceMap dts ts closures runtimeMeta assembly.Raw isLibrary
+let ModifyAssembly (logger: LoggerBase) (comp: Compilation option) (refMeta: M.Info) (current: M.Info) sourceMap dts ts closures runtimeMeta (assembly : Assembly) isLibrary prebundle isSitelet =
+    ModifyCecilAssembly logger comp refMeta current sourceMap dts ts closures runtimeMeta assembly.Raw isLibrary prebundle isSitelet
 
 let AddExtraAssemblyReferences (wsrefs: Assembly seq) (assembly : Assembly) =
     let a = assembly.Raw

--- a/src/compiler/WebSharper.Compiler/FrontEnd.fs
+++ b/src/compiler/WebSharper.Compiler/FrontEnd.fs
@@ -218,9 +218,10 @@ let CreateResources (logger: LoggerBase) (comp: Compilation option) (refMeta: M.
                     let rootJS, addrMap = JavaScriptPackager.packageEntryPointReexport meta
                     let program, _, trAddrMap = rootJS |> WebSharper.Compiler.JavaScriptWriter.transformProgramAndAddrMap O.JavaScript WebSharper.Core.JavaScript.Readable addrMap
                     let js, _, _ = WebSharper.Compiler.JavaScriptPackager.programToString WebSharper.Core.JavaScript.Readable WebSharper.Core.JavaScript.Writer.CodeWriter program false
-                    logger.TimedStage (sprintf "Writing reexports all.js")
+                    let trAddrMap = Dict.union [ trAddrMap; dict [ AST.Address.Global(), assemblyName ] ]
+                    logger.TimedStage (sprintf "Writing reexports root.js")
                     Some [|
-                        "all", js, trAddrMap    
+                        "root", js, trAddrMap    
                     |]
                 else
                     None

--- a/src/compiler/WebSharper.Compiler/JavaScriptPackager.fs
+++ b/src/compiler/WebSharper.Compiler/JavaScriptPackager.fs
@@ -1439,7 +1439,7 @@ let packageEntryPointReexport (runtimeMeta: M.Info) =
                     finalAddrMap.Add(a, x)
                 | i ->
                     let x = Id.New n
-                    namedImports.Add(i, Id.New n)   
+                    namedImports.Add(i, x)   
                     finalAddrMap.Add(a, x)
             let moduleName =
                 match m with

--- a/src/compiler/WebSharper.Compiler/JavaScriptPackager.fs
+++ b/src/compiler/WebSharper.Compiler/JavaScriptPackager.fs
@@ -1433,7 +1433,7 @@ let packageEntryPointReexport (runtimeMeta: M.Info) =
                             m.Name.Replace('.', '_').Replace('`', '_')
                         | DotNetType m -> 
                             (m.Name.Split([| '/'; '.' |]) |> Array.last).Split('`') |> Array.head
-                        | _ -> "default"
+                        | _ -> "x"
                     let x = Id.New newName
                     namedImports.Add("default", x)
                     finalAddrMap.Add(a, x)

--- a/src/compiler/WebSharper.Compiler/JavaScriptWriter.fs
+++ b/src/compiler/WebSharper.Compiler/JavaScriptWriter.fs
@@ -151,6 +151,13 @@ type CollectVariables(env: Environment) =
     override this.VisitAlias(a, _, _) =
         defineId env a |> ignore
 
+    override this.VisitExportDecl(_, s) =
+        match s with 
+        | Import(None, None, namedImports, _) ->
+            namedImports |> List.iter (snd >> defineId env >> ignore)
+        | _ ->
+            this.VisitStatement(s)
+    
     override this.VisitImport(d, f, n, m) =
         if m = "" then
             // global values used
@@ -549,6 +556,14 @@ and transformStatement (env: Environment) (statement: Statement) : J.Statement =
             b |> Option.map (defineId env), 
             c |> List.map (fun (n, x) -> n, defineId env x),
             d)
+    | ExportDecl (a, Import(None, None, b, c)) ->
+        J.Export (a,
+            J.Import(
+                None, 
+                None, 
+                b |> List.map (fun (n, x) -> n, transformId env x),
+                c)
+        )
     | ExportDecl (a, b) ->
         J.Export (a, trS b)
     | Declare a ->

--- a/src/compiler/WebSharper.Compiler/JavaScriptWriter.fs
+++ b/src/compiler/WebSharper.Compiler/JavaScriptWriter.fs
@@ -760,5 +760,6 @@ let transformProgramAndAddrMap output pref (addrMap: IDictionary<Address, Id>) s
     let env = Environment.New(pref, output)
     let cvars = CollectVariables(env)
     statements |> List.iter cvars.VisitStatement
-    let trAddrMap = addrMap |> Dict.map (fun id -> (transformId env id).Name)
-    (statements |> List.map (transformStatement env) |> flattenJS), env.IsJSX.Value, trAddrMap
+    (statements |> List.map (transformStatement env) |> flattenJS), 
+    env.IsJSX.Value, 
+    (addrMap |> Dict.map (fun id -> (transformId env id).Name))

--- a/src/sitelets/WebSharper.Sitelets/Content.fs
+++ b/src/sitelets/WebSharper.Sitelets/Content.fs
@@ -211,8 +211,17 @@ module Content =
                                             let i = "i" + string (imported.Count + 1)
                                             match f.Address |> List.rev with
                                             | [] -> failwith "empty address"
-                                            | _ :: r ->
-                                                let j = i :: r |> String.concat "."
+                                            | a :: r ->
+                                                let j = 
+                                                    match a with
+                                                    | "default" -> 
+                                                        match r with    
+                                                        | [] ->     
+                                                            i :: r |> String.concat "."
+                                                        | _ :: rr ->
+                                                            i :: rr |> String.concat "."
+                                                    | _ ->
+                                                        i :: r |> String.concat "."
                                                 imported.Add(f, j)
                                                 let asmName = bundle[AST.Address.Global()]
                                                 scriptsTw.WriteLine($"""import {{ {b} as {i} }} from "{url}{asmName}/root.js";""")

--- a/src/sitelets/WebSharper.Sitelets/Content.fs
+++ b/src/sitelets/WebSharper.Sitelets/Content.fs
@@ -137,8 +137,13 @@ module Content =
                 |> Seq.collect importsOf
                 |> Array.ofSeq
 
+            let hasRoot =
+                ctx.Metadata.PreBundle.Count = 1 && ctx.Metadata.PreBundle.ContainsKey("root")
+            
             let bundleName = 
-                if ctx.Metadata.PreBundle.Count > 0 && allImports.Length > 0 then
+                if hasRoot then
+                    Some "root"
+                elif ctx.Metadata.PreBundle.Count > 0 && allImports.Length > 0 then
                     match requiredBundles with
                     | [||] ->
                         if ctx.Metadata.PreBundle.ContainsKey("all") then Some "all" else None
@@ -197,7 +202,23 @@ module Content =
                             | None -> None
                             | Some bundle ->
                                 match bundle.TryFind a with
-                                | Some b -> Some ("wsbundle." + b)
+                                | Some b -> 
+                                    if hasRoot then
+                                        match imported.TryGetValue(f) with   
+                                        | true, i ->
+                                            Some i
+                                        | _ ->
+                                            let i = "i" + string (imported.Count + 1)
+                                            match f.Address |> List.rev with
+                                            | [] -> failwith "empty address"
+                                            | _ :: r ->
+                                                let j = i :: r |> String.concat "."
+                                                imported.Add(f, j)
+                                                let asmName = bundle[AST.Address.Global()]
+                                                scriptsTw.WriteLine($"""import {{ {b} as {i} }} from "{url}{asmName}/root.js";""")
+                                                Some j
+                                    else
+                                        Some ("wsbundle." + b)
                                 | None ->
                                     match a.Address with 
                                     | h :: t ->
@@ -272,7 +293,7 @@ module Content =
                         scriptsTw.WriteLine($"""{v}.$postinit("{i}");""")
                     | _ -> ()
 
-            Some activate, bundleName |> Option.map Array.singleton
+            Some activate, if hasRoot then None else bundleName |> Option.map Array.singleton 
         else    
             None, None
 

--- a/tests/Web.FSharp/Main.html
+++ b/tests/Web.FSharp/Main.html
@@ -30,6 +30,7 @@
             margin: 20px 0;
         }
     </style>
+    <script type="module" src="/@vite/client"></script>
 </head>
 <body>
     <!-- Static navbar -->

--- a/tests/Web.FSharp/Startup.fs
+++ b/tests/Web.FSharp/Startup.fs
@@ -24,6 +24,14 @@ type Startup () =
             app.UseDeveloperExceptionPage() |> ignore
 
         app.UseAuthentication()
+            .Use(fun context (next: RequestDelegate) ->
+                if context.Request.Path.StartsWithSegments("/Scripts") || context.Request.Path.StartsWithSegments("/@vite") then
+                    let proxyRequest = context.Request.Path.Value
+                    context.Response.Redirect($"http://localhost:5173{proxyRequest}")
+                    Task.CompletedTask
+                else
+                    next.Invoke(context)
+            )
             .UseStaticFiles()
             .UseWebSharper()
             .Run(fun context ->

--- a/tests/Web.FSharp/Web.FSharp.fsproj
+++ b/tests/Web.FSharp/Web.FSharp.fsproj
@@ -8,6 +8,7 @@
     <WebSharperTypeScriptOutput>False</WebSharperTypeScriptOutput>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="vite.config.js" />
     <Content Include="Main.html" CopyToPublishDirectory="Always" />
     <Compile Include="Startup.fs" />
     <None Include="wsconfig.json" />
@@ -37,6 +38,9 @@
     <ProjectReference Include="..\WebSharper.Web.Tests\WebSharper.Web.Tests.fsproj" />
     <ProjectReference Include="..\Website\Website.fsproj" />
   </ItemGroup>
+  <Target Name="EnsureNodeModulesInstalled" BeforeTargets="Build">
+    <Exec Command="npm install" />
+  </Target>
   <Import Project="..\..\msbuild\WebSharper.FSharp.Internal.targets" />
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/tests/Web.FSharp/package-lock.json
+++ b/tests/Web.FSharp/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Web",
+  "name": "Web.FSharp",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/tests/Web.FSharp/package.json
+++ b/tests/Web.FSharp/package.json
@@ -1,0 +1,8 @@
+{
+  "devDependencies": {
+    "esbuild": "^0.19.9"
+  },
+  "dependencies": {
+    "is-sorted": "^1.0.5"
+  }
+}

--- a/tests/Web.FSharp/vite.config.js
+++ b/tests/Web.FSharp/vite.config.js
@@ -1,0 +1,10 @@
+﻿module.exports = {
+  root: "wwwroot",
+  build: {
+    rollupOptions: {
+      input: [
+        "./Scripts/WebSharper/Web.FSharp/all.js"
+      ]
+    }
+  }
+}

--- a/tests/Web.FSharp/wsconfig.json
+++ b/tests/Web.FSharp/wsconfig.json
@@ -2,5 +2,6 @@
   "$schema": "https://websharper.com/wsconfig.schema.json",
   "project": "web",
   "outputDir": "wwwroot",
-  "downloadResources": true
+  "downloadResources": true,
+  "runtimeMetadata": "full"
 }

--- a/tests/Web/Web.csproj
+++ b/tests/Web/Web.csproj
@@ -38,9 +38,9 @@
   <Target Name="EnsureNodeModulesInstalled" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Release' ">
     <Exec Command="npm install" />
   </Target>
-  <Target Name="RollupBundle" AfterTargets="WebSharperCompile" Condition=" '$(Configuration)' == 'Release' ">
+  <!--<Target Name="RollupBundle" AfterTargets="WebSharperCompile" Condition=" '$(Configuration)' == 'Release' ">
     <Exec Command="node ./esbuild.config.mjs" />
-  </Target>
+  </Target>-->
   <Import Project="..\..\msbuild\WebSharper.CSharp.Internal.targets" />
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/tests/Web/Web.csproj
+++ b/tests/Web/Web.csproj
@@ -35,12 +35,10 @@
     <ProjectReference Include="..\WebSharper.Web.Tests\WebSharper.Web.Tests.fsproj" />
     <ProjectReference Include="..\Website\Website.fsproj" />
   </ItemGroup>
-  <Target Name="EnsureNodeModulesInstalled" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Release' ">
+  <Target Name="RollupBundle" AfterTargets="WebSharperCompile">
     <Exec Command="npm install" />
-  </Target>
-  <!--<Target Name="RollupBundle" AfterTargets="WebSharperCompile" Condition=" '$(Configuration)' == 'Release' ">
     <Exec Command="node ./esbuild.config.mjs" />
-  </Target>-->
+  </Target>
   <Import Project="..\..\msbuild\WebSharper.CSharp.Internal.targets" />
   <Import Project="..\..\.paket\Paket.Restore.targets" />
 </Project>

--- a/tests/Web/package.json
+++ b/tests/Web/package.json
@@ -4,5 +4,8 @@
   },
   "devDependencies": {
     "esbuild": "^0.19.9"
+  },
+  "dependencies": {
+    "is-sorted": "^1.0.5"
   }
 }

--- a/tests/Web/wsconfig.json
+++ b/tests/Web/wsconfig.json
@@ -4,8 +4,8 @@
   "outputDir": "wwwroot",
   "downloadResources": true,
   "runtimeMetadata": "full",
-  "preBundle": true,
+  "preBundle": false,
   "release": {
-    "preBundle": true
+    "preBundle": false
   }
 }

--- a/tests/Web/wsconfig.json
+++ b/tests/Web/wsconfig.json
@@ -4,8 +4,5 @@
   "outputDir": "wwwroot",
   "downloadResources": true,
   "runtimeMetadata": "full",
-  "preBundle": false,
-  "release": {
-    "preBundle": false
-  }
+  "preBundle": true
 }

--- a/tests/WebSharper.Module.Tests/Import.fs
+++ b/tests/WebSharper.Module.Tests/Import.fs
@@ -47,6 +47,9 @@ type MyClassInline [<Inline "new $import()">] () =
 [<Import ("sayHi", "./sayHi.js")>]
 let sayHiFunc (str: string) = X<string> 
 
+[<Import "is-sorted">]
+let isSorted (array: 'T[]) = X<bool> 
+
 [<JavaScript>]
 module JSXTest =
     let html() =
@@ -125,5 +128,10 @@ let Tests =
             equal (WebSharper.InterfaceGenerator.Tests.WIGtest4.SayHiStatic "World") "Hello, World!"
             let c = WebSharper.InterfaceGenerator.Tests.WIGtest4()
             equal (c.SayHiInst "World") "Hello, World!"
+        }
+
+        Test "npm import" {
+            isTrue (isSorted([| 1; 2; 3 |]))
+            isFalse (isSorted([| 1; 3; 2 |]))
         }
     }


### PR DESCRIPTION
Intended for Debug mode use, when Sitelets projects don't have `"prebundle": true`, they will output a `root.js` file that re-exports all needed functions for page initializations. This can be used to run `vite` or another local server tool to make use of npm packages