### PR TITLE
feat: fix DateTime formatting + add support for all the custom formats

### DIFF
--- a/src/stdlib/WebSharper.Main/JavaScript.Pervasives.fs
+++ b/src/stdlib/WebSharper.Main/JavaScript.Pervasives.fs
@@ -123,7 +123,7 @@ let GetJS<'T> (x: obj) (items: seq<string>) =
     let mutable x = x
     for i in items do
         x <- x?(i)
-    As<'T> x    
+    As<'T> x
 
 /// Erases generic parameters inside this expression during WebSharper translation.
 /// You can get use this to translate `defaultof` inside a generic function.
@@ -160,67 +160,343 @@ module Optional =
 [<JavaScript>]
 module DateTime =
     open WebSharper.JavaScript
-    
-    [<Direct("return $str.replace(/(\w)\1*/g, $f)")>]
-    let replace str f = X<string>
 
     [<Inline "new Date($x)">]
     let asJSDate (x: System.DateTime) = X<Date>
 
-    let DateFormatter (date: System.DateTime) (f: string) =
-        let d = asJSDate date
-        let padLeft (minLength: int) (x: string) =
-            if x.Length < minLength then
-                String.replicate (minLength - x.Length) "0" + x
-            else
-                x
-        replace f (fun (m: obj) ->
-            let mString = m |> As<string>
-            match mString.Substring(0, 1) with
-            | "y" ->
-                match mString.Length with
-                | 1 -> d.GetFullYear() % 10 |> string 
-                | 2 -> d.GetFullYear() % 100 |> string |> padLeft 2
-                | 3 -> d.GetFullYear() % 1000 |> string |> padLeft 3
-                | 4 -> d.GetFullYear() |> string |> padLeft 4
-                | 5 -> d.GetFullYear() |> string |> padLeft 5
-                | _ -> mString
-            | "M" ->
-                match mString.Length with
-                | 1 -> d.GetMonth() + 1 |> string 
-                | 2 -> d.GetMonth() + 1 |> string |> padLeft 2
-                | _ -> mString
-            | "d" ->
-                match mString.Length with
-                | 1 -> d.GetMonth() + 1 |> string 
-                | 2 -> d.GetMonth() + 1 |> string |> padLeft 2
-                | _ -> mString
-            | "h" ->
-                let hours = d.GetHours()
-                match mString.Length with
-                | 1 -> (if hours > 12 then hours % 12 else hours) |> string 
-                | 2 -> (if hours > 12 then hours % 12 else hours) |> string |> padLeft 2
-                | _ -> mString
-            | "H" ->
-                let hours = d.GetHours()
-                match mString.Length with
-                | 1 -> hours |> string 
-                | 2 -> hours |> string |> padLeft 2
-                | _ -> mString
-            | "m" ->
-                match mString.Length with
-                | 1 -> d.GetMinutes() |> string 
-                | 2 -> d.GetMinutes() |> string |> padLeft 2
-                | _ -> mString
-            | "s" ->
-                match mString.Length with
-                | 1 -> d.GetSeconds() |> string 
-                | 2 -> d.GetSeconds() |> string |> padLeft 2
-                | _ -> mString
-            | "f" -> d.GetMilliseconds() |> string 
-            | _ -> mString
-        )
+    let private shortDays =
+        [
+            "Sun"; "Mon"; "Tue"; "Wed"; "Thu"; "Fri"; "Sat"
+        ]
+
+    let private longDays =
+        [
+            "Sunday"; "Monday"; "Tuesday"; "Wednesday"; "Thursday"; "Friday"; "Saturday"
+        ]
+
+    let private shortMonths =
+        [
+            "Jan"; "Feb"; "Mar"; "Apr"; "May"; "Jun"; "Jul"; "Aug"; "Sep"; "Oct"; "Nov"; "Dec"
+        ]
+
+    let private longMonths =
+        [
+            "January"; "February"; "March"; "April"; "May"; "June"; "July"; "August"; "September"; "October"; "November"; "December"
+        ]
+
+    let private padLeft (minLength: int) (x: string) =
+        if x.Length < minLength then
+            String.replicate (minLength - x.Length) "0" + x
+        else
+            x
+
+    let private padRight (minLength: int) (x: string) =
+        if x.Length < minLength then
+            x + String.replicate (minLength - x.Length) "0"
+        else
+            x
+
+    let private dateOffsetString (d : Date) =
+        // Should this -60000.0 be applied by the caller instead?
+        let offset = d.GetTimezoneOffset() * -60000.0
+        let isMinus = offset < 0
+        let offset = abs offset
+        let hours = int (offset / 3600000.0) |> string |> padLeft 2
+        let minutes = int ((offset % 3600000.0) / 60000.0) |> string |> padLeft 2
+        let sign = if isMinus then "-" else "+"
         
+        sign + hours + ":" + minutes
+
+    let private parseRepeatToken(format : string) (pos : int) (patternChar : char) =
+        let mutable tokenLength = 0
+        let mutable internalPos = pos
+        while internalPos < format.Length && format.[internalPos] = patternChar do
+            internalPos <- internalPos + 1
+            tokenLength <- tokenLength + 1
+
+        tokenLength
+
+    let private parseNextChar (format: string) (pos: int) =
+        if pos >= format.Length - 1 then
+            None
+        else
+            format.[pos + 1] |> Some
+
+    let private parseQuotedString (format: string) (pos: int) =
+        let beginPos = pos
+        // Get the character used to quote the string
+        let quoteChar = format.[pos]
+
+        let mutable result = ""
+        let mutable foundQuote = false
+        let mutable pos = pos
+        let mutable earlyBreak = false
+
+        while (pos < format.Length && not earlyBreak) do
+            pos <- pos + 1
+            let currentChar = format.[pos]
+            if currentChar = quoteChar then
+                foundQuote <- true
+                earlyBreak <- true
+            elif currentChar = '\\' then
+                if pos < format.Length then
+                    pos <- pos + 1
+                    result <- result + string format.[pos]
+                else
+                    // This means that '\' is the last character in the string.
+                    failwith "Invalid string format"
+            else
+                result <- result + string currentChar
+
+        if not foundQuote then
+            // We could not find the matching quote
+            failwith $"Invalid string format could not find matching quote for {quoteChar}"
+
+        (result, pos - beginPos + 1)
+
+    let rec dateToStringWithCustomFormat (d : Date) (format : string) =
+        let mutable cursorPos = 0
+        let mutable tokenLength = 0
+        let mutable result = ""
+
+        let appendToResult (s: string) =
+            result <- result + s
+
+        while cursorPos < format.Length do
+            printfn "cursorPos: %d" cursorPos
+            let token = format.[cursorPos]
+
+            match token with
+            | 'd' ->
+                tokenLength <- parseRepeatToken format cursorPos 'd'
+                cursorPos <- cursorPos + tokenLength
+
+                match tokenLength with
+                | 1 -> d.GetDate() |> string |> appendToResult
+                | 2 -> d.GetDate() |> string |> padLeft 2 |> appendToResult
+                | 3 -> shortDays.[d.GetDay()] |> string |> appendToResult
+                | 4 | _ -> longDays.[d.GetDay()] |> string |> appendToResult
+            | 'f' ->
+                tokenLength <- parseRepeatToken format cursorPos 'f'
+                cursorPos <- cursorPos + tokenLength
+
+                match tokenLength with
+                | 1 | 2 | 3 ->
+                    let precision = 10.0 ** (3.0 - float tokenLength) |> int
+                    let ms = d.GetMilliseconds()
+                    (ms / precision) |> string |> padLeft tokenLength |> appendToResult
+                | 4 | 5 | 6 | 7 ->
+                    let ms = d.GetMilliseconds()
+                    ms |> string |> padRight tokenLength |> appendToResult
+                | _ -> failwith "Input string was not in a correct format."
+            | 'F' ->
+                tokenLength <- parseRepeatToken format cursorPos 'F'
+                cursorPos <- cursorPos + tokenLength
+
+                match tokenLength with
+                | 1 | 2 | 3 ->
+                    let precision = 10.0 ** (3.0 - float tokenLength) |> int 
+                    let value = d.GetMilliseconds() / precision
+                    if value <> 0 then
+                        value |> string |> padLeft tokenLength |> appendToResult
+                | 4 | 5 | 6 | 7 ->
+                    let value = d.GetMilliseconds()
+                    if value <> 0 then
+                        value |> string |> padLeft 3 |> appendToResult
+                | _ -> failwith "Input string was not in a correct format."
+            | 'g' ->
+                tokenLength <- parseRepeatToken format cursorPos 'g'
+                cursorPos <- cursorPos + tokenLength
+
+                // Behave like CultureInfo.InvariantCulture
+                "A.D." |> appendToResult
+            
+            | 'h' ->
+                tokenLength <- parseRepeatToken format cursorPos 'h'
+                cursorPos <- cursorPos + tokenLength
+
+                let hours = d.GetHours() % 12
+                
+                match tokenLength with
+                | 1 -> 
+                    if hours = 0 then
+                        "12" 
+                    else
+                        hours |> string
+                | 2 | _ -> 
+                    if hours = 0 then
+                        "12"
+                    else
+                        hours |> string |> padLeft 2
+                |> appendToResult
+
+            | 'H' ->
+                tokenLength <- parseRepeatToken format cursorPos 'H'
+                cursorPos <- cursorPos + tokenLength
+
+                let hours = d.GetHours()
+                match tokenLength with
+                | 1 -> hours |> string
+                | 2 | _ -> hours |> string |> padLeft 2
+                |> appendToResult
+
+            | 'K' -> 
+                tokenLength <- parseRepeatToken format cursorPos 'K'
+                cursorPos <- cursorPos + tokenLength
+
+                dateOffsetString d
+                |> String.replicate tokenLength
+                |> appendToResult
+                
+            | 'm' ->
+                tokenLength <- parseRepeatToken format cursorPos 'm'
+                cursorPos <- cursorPos + tokenLength
+
+                match tokenLength with
+                | 1 -> d.GetMinutes() |> string
+                | 2 | _ -> d.GetMinutes() |> string |> padLeft 2
+                |> appendToResult
+
+            | 'M' ->
+                tokenLength <- parseRepeatToken format cursorPos 'M'
+                cursorPos <- cursorPos + tokenLength
+
+                match tokenLength with
+                | 1 -> d.GetMonth() + 1 |> string
+                | 2 -> d.GetMonth() + 1 |> string |> padLeft 2
+                | 3 -> shortMonths.[d.GetMonth()] |> string
+                | 4 | _ -> longMonths.[d.GetMonth()] |> string
+                |> appendToResult
+
+            | 's' ->
+                tokenLength <- parseRepeatToken format cursorPos 's'
+                cursorPos <- cursorPos + tokenLength
+
+                match tokenLength with
+                | 1 -> d.GetSeconds() |> string
+                | 2 | _ -> d.GetSeconds() |> string |> padLeft 2
+                |> appendToResult
+
+            | 't' ->
+                tokenLength <- parseRepeatToken format cursorPos 't'
+                cursorPos <- cursorPos + tokenLength
+
+                match tokenLength with
+                | 1 -> if d.GetHours() < 12 then "A" else "P"
+                | 2 | _ -> if d.GetHours() < 12 then "AM" else "PM"
+                |> appendToResult
+
+            | 'y' ->
+                tokenLength <- parseRepeatToken format cursorPos 'y'
+                cursorPos <- cursorPos + tokenLength
+
+                match tokenLength with
+                | 1 -> d.GetFullYear() % 100 |> string
+                | 2 -> d.GetFullYear() % 100 |> string |> padLeft 2
+                | _ -> d.GetFullYear() |> string |> padLeft tokenLength
+                |> appendToResult
+            | 'z' ->        
+                tokenLength <- parseRepeatToken format cursorPos 'z'
+                cursorPos <- cursorPos + tokenLength
+
+                // WebSharper only support DateTimeKind.Local code to get the offset 
+                // should be adapted if more DateTimeKind are supported in the future
+                let utcOffsetText = dateOffsetString d
+
+                let sign = utcOffsetText.Substring(0, 1)
+                // Hours and minutes are always 2 digits (02, 13, etc.)
+                let hours = utcOffsetText.Substring(1, 2)
+                let minutes = utcOffsetText.Substring(4, 2)
+
+                match tokenLength with
+                | 1 -> 
+                    // Remove leading zero if present
+                    let nonLeadingZero = 
+                        if hours.StartsWith("0") then hours.Substring(1) else hours
+
+                    sign + nonLeadingZero
+                | 2 -> sign + hours
+                | _ -> sign + hours + ":" + minutes
+                |> appendToResult
+
+            | ':' -> 
+                cursorPos <- cursorPos + 1
+                ":" |> appendToResult
+            | '/' -> 
+                cursorPos <- cursorPos + 1
+                "/" |> appendToResult
+            | '\''
+            | '"' -> 
+                let quotedString, quotedStringLenght = parseQuotedString format cursorPos
+                cursorPos <- cursorPos + quotedStringLenght
+                quotedString |> appendToResult
+            | '%' ->
+                // Using a if statement make the code a bit more readable
+                // compared to using a match statement
+                let nextChar = parseNextChar format cursorPos
+                if nextChar.IsSome && nextChar.Value <> '%' then
+                    cursorPos <- cursorPos + 2
+                    dateToStringWithCustomFormat d (string nextChar.Value) |> appendToResult
+                else
+                    failwith "Invalid format string"
+            | '\\' ->
+                match parseNextChar format cursorPos with
+                | Some nextChar2 ->
+                    cursorPos <- cursorPos + 2
+                    string nextChar2 |> appendToResult
+                | None ->
+                    failwith "Invalid format string"
+            | _ ->
+                token |> string |> appendToResult
+                cursorPos <- cursorPos + 1
+
+        result            
+    
+
+    let DateFormatter (date: System.DateTime) (format: string) =
+        let d = asJSDate date
+
+        match format with 
+        | "D" -> 
+            (longDays.[d.GetDay()] |> string)
+            + ", "
+            + (d.GetDate() |> string |> padLeft 2)
+            + " "
+            + (longMonths.[d.GetMonth()] |> string)
+            + " "
+            + (d.GetFullYear() |> string)
+        | "d" -> 
+            (d.GetMonth() + 1 |> string |> padLeft 2)
+            + "/"
+            + (d.GetDate() |> string |> padLeft 2)
+            + "/"
+            + (d.GetFullYear() |> string)
+        | "T" ->
+            (d.GetHours() |> string |> padLeft 2)
+            + ":"
+            + (d.GetMinutes() |> string |> padLeft 2)
+            + ":"
+            + (d.GetSeconds() |> string |> padLeft 2)
+        | "t" ->
+            (d.GetHours() |> string |> padLeft 2)
+            + ":"
+            + (d.GetMinutes() |> string |> padLeft 2)
+        | "O" | "o" -> 
+            (d.GetFullYear() |> string)
+            + "-"
+            + ((d.GetMonth() + 1) |> string |> padLeft 2)
+            + "-"
+            + (d.GetDate() |> string |> padLeft 2)
+            + "T"
+            + (d.GetHours() |> string |> padLeft 2)
+            + ":"
+            + (d.GetMinutes() |> string |> padLeft 2)
+            + ":"
+            + (d.GetSeconds() |> string |> padLeft 2)
+            + "."
+            + (d.GetMilliseconds() |> string |> padLeft 3)
+            + dateOffsetString d
+        | _ -> dateToStringWithCustomFormat d format
 
 module Union =
 // {{ generated by genInterop.fsx, do not modify

--- a/tests/WebSharper.Tests/DateTime.fs
+++ b/tests/WebSharper.Tests/DateTime.fs
@@ -231,6 +231,294 @@ let Tests =
             isTrue (DateTime.IsLeapYear 2020)
             isFalse (DateTime.IsLeapYear 2100)
         }
+
+        // ToString with custom format test is split in different parts
+        // otherwise the compilation hangs for ever (seems to be a bug)
+
+        Test "ToString with custom format works (Part #1)" {
+            equal (DateTime(2014, 7, 1, 16, 37, 1, 2).ToString("r d")) "r 1"
+            equal (DateTime(2014, 7, 13, 16, 37, 1, 2).ToString("r d")) "r 13"
+
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r dd")) "r 01"
+            equal (DateTime(2014, 7, 21, 16, 37, 0).ToString("r dd")) "r 21"
+
+            equal (DateTime(2014, 7, 7, 16, 37, 0).ToString("r ddd")) "r Mon"
+            equal (DateTime(2014, 7, 8, 16, 37, 0).ToString("r ddd")) "r Tue"
+            equal (DateTime(2014, 7, 9, 16, 37, 0).ToString("r ddd")) "r Wed"
+            equal (DateTime(2014, 7, 10, 16, 37, 0).ToString("r ddd")) "r Thu"
+            equal (DateTime(2014, 7, 11, 16, 37, 0).ToString("r ddd")) "r Fri"
+            equal (DateTime(2014, 7, 12, 16, 37, 0).ToString("r ddd")) "r Sat"
+            equal (DateTime(2014, 7, 13, 16, 37, 0).ToString("r ddd")) "r Sun"
+
+            equal (DateTime(2014, 7, 7, 16, 37, 0).ToString("r dddd")) "r Monday"
+            equal (DateTime(2014, 7, 8, 16, 37, 0).ToString("r dddd")) "r Tuesday"
+            equal (DateTime(2014, 7, 9, 16, 37, 0).ToString("r dddd")) "r Wednesday"
+            equal (DateTime(2014, 7, 10, 16, 37, 0).ToString("r dddd")) "r Thursday"
+            equal (DateTime(2014, 7, 11, 16, 37, 0).ToString("r dddd")) "r Friday"
+            equal (DateTime(2014, 7, 12, 16, 37, 0).ToString("r dddd")) "r Saturday"
+            equal (DateTime(2014, 7, 13, 16, 37, 0).ToString("r dddd")) "r Sunday"
+
+            equal (DateTime.Parse("2009-06-15T13:45:30.6175425").ToString("r f")) "r 6"
+            equal (DateTime.Parse("2009-06-15T13:45:30.05").ToString("r f")) "r 0"
+            equal (DateTime.Parse("2009-06-15T13:45:30.6175425").ToString("r ff")) "r 61"
+            equal (DateTime.Parse("2009-06-15T13:45:30.0050000").ToString("r ff")) "r 00"
+            equal (DateTime.Parse("2009-06-15T13:45:30.6175425").ToString("r fff")) "r 617"
+            equal (DateTime.Parse("2009-06-15T13:45:30.0005000").ToString("r fff")) "r 000"
+            // JavaScript Date only support precision to the millisecond so we fill with 0
+            equal (DateTime.Parse("2009-06-15T13:45:30.617").ToString("r ffff")) "r 6170"
+            equal (DateTime.Parse("2009-06-15T13:45:30.000").ToString("r ffff")) "r 0000"
+            equal (DateTime.Parse("2009-06-15T13:45:30.617").ToString("r fffff")) "r 61700"
+            equal (DateTime.Parse("2009-06-15T13:45:30.000").ToString("r fffff")) "r 00000"
+            equal (DateTime.Parse("2009-06-15T13:45:30.617").ToString("r ffffff")) "r 617000"
+            equal (DateTime.Parse("2009-06-15T13:45:30.000").ToString("r ffffff")) "r 000000"
+            equal (DateTime.Parse("2009-06-15T13:45:30.617").ToString("r fffffff")) "r 6170000"
+        }
+        
+        Test "ToString with custom format works (Part #2)" {
+            equal (DateTime.Parse("2009-06-15T13:45:30.6175425").ToString("r F")) "r 6"
+            equal (DateTime.Parse("2009-06-15T13:45:30.05").ToString("r F")) "r "
+            equal (DateTime.Parse("2009-06-15T13:45:30.6175425").ToString("r FF")) "r 61"
+            equal (DateTime.Parse("2009-06-15T13:45:30.0050000").ToString("r FF")) "r "
+            equal (DateTime.Parse("2009-06-15T13:45:30.6175425").ToString("r FFF")) "r 617"
+            equal (DateTime.Parse("2009-06-15T13:45:30.0005000").ToString("r FFF")) "r "
+            // JavaScript Date only support precision to the millisecond so we fill with 0
+            equal (DateTime.Parse("2009-06-15T13:45:30.617").ToString("r FFFF")) "r 617"
+            equal (DateTime.Parse("2009-06-15T13:45:30.000").ToString("r FFFF")) "r "
+            equal (DateTime.Parse("2009-06-15T13:45:30.617").ToString("r FFFFF")) "r 617"
+            equal (DateTime.Parse("2009-06-15T13:45:30.000").ToString("r FFFFF")) "r "
+            equal (DateTime.Parse("2009-06-15T13:45:30.061").ToString("r FFFFFF")) "r 061"
+            equal (DateTime.Parse("2009-06-15T13:45:30.000").ToString("r FFFFFF")) "r "
+            equal (DateTime.Parse("2009-06-15T13:45:30.617").ToString("r FFFFFFF")) "r 617"
+            equal (DateTime.Parse("2009-06-15T13:45:30.000").ToString("r FFFFFFF")) "r "
+
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r g")) "r A.D."
+
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r gg")) "r A.D."
+
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r gg ggggg")) "r A.D. A.D."
+
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r h")) "r 4"
+            equal (DateTime(2014, 7, 1, 4, 37, 0).ToString("r h")) "r 4"
+            // Test edge case where hour is 12
+            equal (DateTime(2014, 7, 1, 0, 0, 0).ToString("r h")) "r 12"
+            equal (DateTime(2014, 7, 1, 12, 0, 0).ToString("r h")) "r 12"
+
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r hh")) "r 04"
+            equal (DateTime(2014, 7, 1, 4, 37, 0).ToString("r hh")) "r 04"
+            // Test edge case where hour is 12
+            equal (DateTime(2014, 7, 1, 0, 0, 0).ToString("r hh")) "r 12"
+            equal (DateTime(2014, 7, 1, 12, 0, 0).ToString("r hh")) "r 12"
+
+            equal (DateTime(2014, 7, 1, 4, 37, 0).ToString("r H")) "r 4"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r H")) "r 16"
+
+            equal (DateTime(2014, 7, 1, 4, 37, 0).ToString("r HH")) "r 04"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r HH")) "r 16"
+                
+            // WebSharper dates are always in local time
+            // equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r K")) "r "
+            // equal (DateTime(2014, 7, 1, 16, 37, 0, DateTimeKind.Utc).ToString("r K")) "r Z"
+
+            // Timezone dependent (test is configured for Europe/Paris timezone)
+            // Commented below it the equivalent test for .NET
+            // equal (DateTime(2014, 7, 1, 16, 37, 0, DateTimeKind.Local).ToString("r K")) "r +02:00"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r K")) "r +02:00"
+
+            // WebSharper dates are always in local time
+            // equal (DateTime(2014, 7, 1, 16, 37, 0, DateTimeKind.Unspecified).ToString("r K")) "r "
+
+            equal (DateTime(2014, 7, 1, 16, 3, 0).ToString("r m")) "r 3"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r m")) "r 37"
+
+            equal (DateTime(2014, 7, 1, 16, 3, 0).ToString("r mm")) "r 03"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r mm")) "r 37"
+
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r M")) "r 7"
+            equal (DateTime(2014, 11, 1, 16, 37, 0).ToString("r M")) "r 11"
+
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r MM")) "r 07"
+            equal (DateTime(2014, 11, 1, 16, 37, 0).ToString("r MM")) "r 11"
+        }
+
+        Test "ToString with custom format works (Part #3)" {
+            equal (DateTime(2014, 1, 1, 16, 37, 0).ToString("r MMM")) "r Jan"
+            equal (DateTime(2014, 2, 1, 16, 37, 0).ToString("r MMM")) "r Feb"
+            equal (DateTime(2014, 3, 1, 16, 37, 0).ToString("r MMM")) "r Mar"
+            equal (DateTime(2014, 4, 1, 16, 37, 0).ToString("r MMM")) "r Apr"
+            equal (DateTime(2014, 5, 1, 16, 37, 0).ToString("r MMM")) "r May"
+            equal (DateTime(2014, 6, 1, 16, 37, 0).ToString("r MMM")) "r Jun"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r MMM")) "r Jul"
+            equal (DateTime(2014, 8, 1, 16, 37, 0).ToString("r MMM")) "r Aug"
+            equal (DateTime(2014, 9, 1, 16, 37, 0).ToString("r MMM")) "r Sep"
+            equal (DateTime(2014, 10, 1, 16, 37, 0).ToString("r MMM")) "r Oct"
+            equal (DateTime(2014, 11, 1, 16, 37, 0).ToString("r MMM")) "r Nov"
+            equal (DateTime(2014, 12, 1, 16, 37, 0).ToString("r MMM")) "r Dec"
+
+            equal (DateTime(2014, 1, 1, 16, 37, 0).ToString("r MMMM")) "r January"
+            equal (DateTime(2014, 2, 1, 16, 37, 0).ToString("r MMMM")) "r February"
+            equal (DateTime(2014, 3, 1, 16, 37, 0).ToString("r MMMM")) "r March"
+            equal (DateTime(2014, 4, 1, 16, 37, 0).ToString("r MMMM")) "r April"
+            equal (DateTime(2014, 5, 1, 16, 37, 0).ToString("r MMMM")) "r May"
+            equal (DateTime(2014, 6, 1, 16, 37, 0).ToString("r MMMM")) "r June"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r MMMM")) "r July"
+            equal (DateTime(2014, 8, 1, 16, 37, 0).ToString("r MMMM")) "r August"
+            equal (DateTime(2014, 9, 1, 16, 37, 0).ToString("r MMMM")) "r September"
+            equal (DateTime(2014, 10, 1, 16, 37, 0).ToString("r MMMM")) "r October"
+            equal (DateTime(2014, 11, 1, 16, 37, 0).ToString("r MMMM")) "r November"
+            equal (DateTime(2014, 12, 1, 16, 37, 0).ToString("r MMMM")) "r December"
+        }
+
+        Test "ToString with custom format works (Part #4)" {
+            equal (DateTime(2014, 7, 1, 16, 37, 3).ToString("r s")) "r 3"
+            equal (DateTime(2014, 7, 1, 16, 37, 31).ToString("r s")) "r 31"
+
+            equal (DateTime(2014, 7, 1, 16, 37, 3).ToString("r ss")) "r 03"
+            equal (DateTime(2014, 7, 1, 16, 37, 31).ToString("r ss")) "r 31"
+
+            equal (DateTime(2014, 7, 1, 1, 37, 0).ToString("r t")) "r A"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r t")) "r P"
+            equal (DateTime(2014, 7, 1, 1, 37, 0).ToString("r tt")) "r AM"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r tt")) "r PM"
+
+            // WS has a bug when year is below 100 
+            // See: https://github.com/dotnet-websharper/core/issues/1433
+            // equal (DateTime(1,1,1).ToString("r y")) "r 1"
+            equal (DateTime(0900,1,1).ToString("r y")) "r 0"
+            equal (DateTime(1900,1,1).ToString("r y")) "r 0"
+            equal (DateTime(2009,1,1).ToString("r y")) "r 9"
+            equal (DateTime(2019,1,1).ToString("r y")) "r 19"
+
+            // WS has a bug when year is below 100 
+            // See: https://github.com/dotnet-websharper/core/issues/1433
+            // equal (DateTime(1,1,1).ToString("r yy")) "r 01"
+            equal (DateTime(0900,1,1).ToString("r yy")) "r 00"
+            equal (DateTime(1900,1,1).ToString("r yy")) "r 00"
+            equal (DateTime(2009,1,1).ToString("r yy")) "r 09"
+            equal (DateTime(2019,1,1).ToString("r yy")) "r 19"
+
+            // WS has a bug when year is below 100 
+            // See: https://github.com/dotnet-websharper/core/issues/1433
+            // equal (DateTime(1,1,1).ToString("r yyy")) "r 001"
+            equal (DateTime(0900,1,1).ToString("r yyy")) "r 900"
+            equal (DateTime(1900,1,1).ToString("r yyy")) "r 1900"
+            equal (DateTime(2009,1,1).ToString("r yyy")) "r 2009"
+            equal (DateTime(2019,1,1).ToString("r yyy")) "r 2019"
+
+            // WS has a bug when year is below 100 
+            // See: https://github.com/dotnet-websharper/core/issues/1433
+            // equal (DateTime(1,1,1).ToString("r yyyy")) "r 0001"
+            equal (DateTime(0900,1,1).ToString("r yyyy")) "r 0900"
+            equal (DateTime(1900,1,1).ToString("r yyyy")) "r 1900"
+            equal (DateTime(2009,1,1).ToString("r yyyy")) "r 2009"
+            equal (DateTime(2019,1,1).ToString("r yyyy")) "r 2019"
+
+            // WS has a bug when year is below 100 
+            // See: https://github.com/dotnet-websharper/core/issues/1433
+            // equal (DateTime(1,1,1).ToString("r yyyyy")) "r 00001"
+            equal (DateTime(0900,1,1).ToString("r yyyyy")) "r 00900"
+            equal (DateTime(1900,1,1).ToString("r yyyyy")) "r 01900"
+            equal (DateTime(2009,1,1).ToString("r yyyyy")) "r 02009"
+            equal (DateTime(2019,1,1).ToString("r yyyyy")) "r 02019"
+        }
+
+        Test "ToString with custom format works (Part #5)" {
+            // Timezone dependent (test is configured for Europe/Paris timezone)
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r z")) "r +2"
+            // equal (DateTime(2014, 7, 1, 16, 37, 0, DateTimeKind.Local).ToString("r z")) "r +2"
+ 
+            // equal (DateTime(2014, 7, 1, 16, 37, 0, DateTimeKind.Utc).ToString("r zz")) "r +00"
+            // // Timezone dependent (test is configured for Europe/Paris timezone)
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r zz")) "r +02"
+            // equal (DateTime(2014, 7, 1, 16, 37, 0, DateTimeKind.Local).ToString("r zz")) "r +02"
+
+            // equal (DateTime(2014, 7, 1, 16, 37, 0, DateTimeKind.Utc).ToString("r zzz")) "r +00:00"
+            // // Timezone dependent (test is configured for Europe/Paris timezone)
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r zzz")) "r +02:00"
+            // equal (DateTime(2014, 7, 1, 16, 37, 0, DateTimeKind.Local).ToString("r zzz")) "r +02:00"
+
+            // Time separator
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r :")) "r :"
+
+            // Date separator
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r /")) "r /"
+
+            // String quotation
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r \"hh\" h")) "r hh 4"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r 'hh' h")) "r hh 4"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r \'hh\'")) "r hh"
+
+            // Format character
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r %h")) "r 4"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r %hh")) "r 44"
+
+            // Escape character
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r \zz")) "r z+2"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r \\zz")) "r z+2"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r \\\zz")) "r \+02"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r \\z\\z")) "r zz"
+
+            // Escape character with verbatim string
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("""r \zz""")) "r z+2"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("""r \\zz""")) "r \+02"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("""r \\\zz""")) "r \z+2"
+        }
+
+        Test "ToString with custom format works (Part #6)" {
+            // The tests below are for testing the behaviour when going outside
+            // of the standard token ranges.
+            // For example, the known tokens range for 'H' are "H", "HH", so
+            // we want to test what happens when we do "HHH" or "HHHH" or "HHHHH"
+            // In general, the tests below check what happens when right outside of the known
+            // token ranges and in another exagerated case
+            
+            equal (DateTime(2014, 7, 13, 16, 37, 0).ToString("r dddd dddddd")) "r Sunday Sunday"
+
+            // Can't test ffffffffffffff because there don't seems to be a helpers
+            // for testing exception in WebSharper.Testing and using try ... with
+            // don't seems to b worth it
+
+            // Can't test FFFFFFFFFFFFFF because there don't seems to be a helpers
+            // for testing exception in WebSharper.Testing and using try ... with
+            // don't seems to b worth it
+
+            equal (DateTime(2014, 7, 1, 12, 0, 0).ToString("r hhh hhhhh")) "r 12 12"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r HHH HHHHHHHH")) "r 16 16"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r KK KKK")) "r +02:00+02:00 +02:00+02:00+02:00"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r mmm mmmm")) "r 37 37"
+            equal (DateTime(2014, 12, 1, 16, 37, 0).ToString("r MMMMM MMMMMMMMM")) "r December December"
+            equal (DateTime(2014, 7, 1, 16, 37, 31).ToString("r sss ssssss")) "r 31 31"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r ttt ttttttt")) "r PM PM"
+            equal (DateTime(2019,1,1).ToString("r yyyyyy yyyyyyyyyy")) "r 002019 0000002019"
+            equal (DateTime(2014, 7, 1, 16, 37, 0).ToString("r zzzz zzzzzz")) "r +02:00 +02:00"
+        }
+
+        Test "DateTime.ToString without separator works" {
+            equal (DateTime(2017, 9, 5).ToString("yyyyMM")) "201709"
+        }
+
+        Test "DateTime.ToString('O') works" {
+            // On .NET the result is "2014-09-11T16:37:02.0000000+02:00"
+            // but because of JavaScript date precission we remove some trailing zero
+            equal (DateTime(2014, 9, 11, 16, 37, 2).ToString("O")) "2014-09-11T16:37:02.000+02:00"
+            equal (DateTime(2014, 9, 11, 16, 37, 2).ToString("o")) "2014-09-11T16:37:02.000+02:00"
+        }
+
+        Test "DateTime.ToString('D') works" {
+            equal (DateTime(2014, 9, 1, 16, 37, 2).ToString("D")) "Monday, 01 September 2014"
+        }
+
+        Test "DateTime.ToString('d') works" {
+            equal (DateTime(2014, 9, 1, 16, 37, 2).ToString("d")) "09/01/2014"
+        }
+
+        Test "DateTime.ToString('T') works" {
+            equal (DateTime(2014, 9, 1, 6, 7, 2).ToString("T")) "06:07:02"
+        }
+
+        Test "DateTime.ToString('t') works" {
+            equal (DateTime(2014, 9, 1, 6, 7, 2).ToString("t")) "06:07"
+        }
+
     }
 
 [<JavaScript>]


### PR DESCRIPTION
Hello,

This PR was originally to add support for `DateTime.ToString("O")` but when looking at the implementation I found out that some of the custom format were not implemented correctly.

For example, `d` was returning the month instead of the day

```fs
  | "d" ->
      match mString.Length with
      | 1 -> d.GetMonth() + 1 |> string 
      | 2 -> d.GetMonth() + 1 |> string |> padLeft 2
      | _ -> mString
```

So I took this opportunity to fix the wrongly implemented custom format and add support for all the custom format supported by .NET.

Some of the custom format, are dependent on the globalization and in these case I took the decision to implement they as if `CultureInfo.Invariant` was provided.

Fix  #1429 