### PR TITLE
Fix WebHost warnings from `tests/` due to .NET 10

### DIFF
--- a/tests/Web.FSharp/Startup.fs
+++ b/tests/Web.FSharp/Startup.fs
@@ -37,8 +37,9 @@ type Startup () =
 
 [<EntryPoint>]
 let main args =
-    WebHost.CreateDefaultBuilder(args)
-        .UseStartup<Startup>()
+    Host.CreateDefaultBuilder(args)
+        .ConfigureWebHostDefaults(fun webHostBuilder ->
+            webHostBuilder.UseStartup<Startup>() |> ignore)
         .Build()
         .Run()
     0

--- a/tests/Web.TypeScript/Startup.cs
+++ b/tests/Web.TypeScript/Startup.cs
@@ -48,8 +48,11 @@ namespace Web
             //    .UseContentRoot(System.IO.Directory.GetCurrentDirectory())
             //    .UseIIS()
             //    .UseIISIntegration()
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webHostBuilder =>
+                {
+                    webHostBuilder.UseStartup<Startup>();
+                })
                 .Build()
                 .Run();
         }

--- a/tests/Web/Startup.cs
+++ b/tests/Web/Startup.cs
@@ -47,8 +47,11 @@ namespace Web
             //    .UseContentRoot(System.IO.Directory.GetCurrentDirectory())
             //    .UseIIS()
             //    .UseIISIntegration()
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webHostBuilder =>
+                {
+                    webHostBuilder.UseStartup<Startup>();
+                })
                 .Build()
                 .Run();
         }


### PR DESCRIPTION
## Description:

Fix WebHost warnings from `tests/` due to .NET 10 breaking change.

The warning message:

> warning FS0044: This construct is deprecated. IWebHost is obsolete. Use IHost instead. For more information, visit https://aka.ms/aspnet/deprecate/008.

---

*If we use `ConfigureWebHost` instead of `ConfigureWebHostDefaults` method, the server doesn't start properly. Example error log:

```bash
Unhandled exception. System.AggregateException: Some services are not able to be constructed (Error while validating the service descriptor 'ServiceType: Microsoft.Extensions.Hosting.IHostedService Lifetime: Singleton ImplementationType: Microsoft.AspNetCore.Hosting.GenericWebHostService': Unable to resolve service for type 'Microsoft.AspNetCore.Hosting.Server.IServer' while attempting to activate 'Microsoft.AspNetCore.Hosting.GenericWebHostService'.)
 ---> System.InvalidOperationException: Error while validating the service descriptor 'ServiceType: Microsoft.Extensions.Hosting.IHostedService Lifetime: Singleton ImplementationType: Microsoft.AspNetCore.Hosting.GenericWebHostService': Unable to resolve service for type 'Microsoft.AspNetCore.Hosting.Server.IServer' while attempting to activate 'Microsoft.AspNetCore.Hosting.GenericWebHostService'.
 ---> System.InvalidOperationException: Unable to resolve service for type 'Microsoft.AspNetCore.Hosting.Server.IServer' while attempting to activate 'Microsoft.AspNetCore.Hosting.GenericWebHostService'.
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateArgumentCallSites(ServiceIdentifier serviceIdentifier, Type implementationType, CallSiteChain callSiteChain, ParameterInfo[] parameters, Boolean throwIfCallSiteNotFound)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateConstructorCallSite(ResultCache lifetime, ServiceIdentifier serviceIdentifier, Type implementationType, CallSiteChain callSiteChain)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateExact(ServiceDescriptor descriptor, ServiceIdentifier serviceIdentifier, CallSiteChain callSiteChain, Int32 slot)
   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.GetCallSite(ServiceDescriptor serviceDescriptor, CallSiteChain callSiteChain)
   at Microsoft.Extensions.DependencyInjection.ServiceProvider.ValidateService(ServiceDescriptor descriptor)
   --- End of inner exception stack trace ---
   at Microsoft.Extensions.DependencyInjection.ServiceProvider.ValidateService(ServiceDescriptor descriptor)
   at Microsoft.Extensions.DependencyInjection.ServiceProvider..ctor(ICollection`1 serviceDescriptors, ServiceProviderOptions options)
   --- End of inner exception stack trace ---
   at Microsoft.Extensions.DependencyInjection.ServiceProvider..ctor(ICollection`1 serviceDescriptors, ServiceProviderOptions options)
   at Microsoft.Extensions.DependencyInjection.ServiceCollectionContainerBuilderExtensions.BuildServiceProvider(IServiceCollection services, ServiceProviderOptions options)
   at Microsoft.Extensions.Hosting.HostBuilder.InitializeServiceProvider()
   at Microsoft.Extensions.Hosting.HostBuilder.Build()
   at Startup.main(String[] args) in .../tests/Web.FSharp/Startup.fs:line 40
```