### PR TITLE
fix(compiler): prevent host System.Private.CoreLib from leaking into target assembly references

### DIFF
--- a/src/compiler/WebSharper.Compiler/FrontEnd.fs
+++ b/src/compiler/WebSharper.Compiler/FrontEnd.fs
@@ -606,8 +606,14 @@ let AddWebResourceAnnotations (assembly : Assembly) (projectDir: string) (files:
 
     let webResourceCtor =
         lazy
-            typeof<WebSharper.WebResourceAttribute>.GetConstructor([| typeof<string>; typeof<string> |])
-            |> a.MainModule.ImportReference
+            let t = typeof<WebSharper.WebResourceAttribute>
+            let asmName = t.Assembly.GetName()
+            let wsRef = Mono.Cecil.AssemblyNameReference(asmName.Name, asmName.Version)
+            let declType = Mono.Cecil.TypeReference(t.Namespace, t.Name, a.MainModule, wsRef)
+            let m = Mono.Cecil.MethodReference(".ctor", a.MainModule.TypeSystem.Void, declType)
+            m.Parameters.Add(Mono.Cecil.ParameterDefinition(a.MainModule.TypeSystem.String))
+            m.Parameters.Add(Mono.Cecil.ParameterDefinition(a.MainModule.TypeSystem.String))
+            m
 
     for file in files do
         let attr = Mono.Cecil.CustomAttribute(webResourceCtor.Value)


### PR DESCRIPTION
Hello,

When a WebSharper project has `extra.files` entries, the compiler is adding `[<WebSharper.WebResource>]` attributes to the output assembly.

The constructor was being resolved via .NET reflection `typeof<string>.GetConstructor(...)`, then imported with Cecil's `ImportReference`. `ImportReference` traces every type it references, including parameter types, back to their declaring assembly. 

Since `typeof<string>` resolves against the **host process's runtime**, on .NET 10 that assembly is `System.Private.CoreLib 10.0.0.0`, which gets recorded as a dependency in the output DLL.

This results in a version mismatch - the project targets `net8.0` but declares a hard dependency on the .NET 10 runtime library.

This causes the debugger to crash the C# compiler expression evaluation, when inspecting a DLL modified by WS 10.

> error CS1705: Assembly 'Scatter' with identity 'Scatter, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' uses 'System.Private.CoreLib, Version=10.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e' which has a higher version than referenced assembly 'System.Private.CoreLib' with identity 'System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e'

> [!NOTE]
> It looks like `WIGCompile.fs` does not have the same problem because `correctType` is already handling the redirects correctly.